### PR TITLE
Fix label cleanup checkout and OIDC defaults

### DIFF
--- a/.github/workflows/agent-label.yml
+++ b/.github/workflows/agent-label.yml
@@ -52,6 +52,10 @@ jobs:
       needs.agent.outputs.should_respond == 'true'
     runs-on: ${{ fromJson(vars.AGENT_RUNS_ON || '["ubuntu-latest"]') }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ github.token }}
+
       - name: Resolve GitHub auth
         id: auth
         uses: ./.github/actions/resolve-github-auth


### PR DESCRIPTION
## Summary
- Add an explicit checkout step before the label cleanup job uses the local resolve-github-auth action.
- Update hosted OIDC auth defaults to use the Sepo broker endpoint and audience.

## Changes
- `OIDC_EXCHANGE_URL`: `https://oidc.self-evolving.app/api/github/github-app-token-exchange`
- `OIDC_AUDIENCE`: `sepo`

## Verification
- `git diff --check`
- `npm --prefix .agent ci`
- `npm --prefix .agent test`