### PR TITLE
Refresh contributor issue associations

### DIFF
--- a/.agent/docs/access-policy.md
+++ b/.agent/docs/access-policy.md
@@ -77,4 +77,4 @@ Organization membership detection depends on what the agent's GitHub token can s
 
 ## Issue-body association refresh
 
-For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before rejecting the request. This covers cases where the webhook payload reports `NONE` but the live issue API reports a stronger association such as `MEMBER`, so valid issue-body mentions are not rejected because of stale event metadata.
+For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before access decisions when the webhook payload reports a weaker value (for example `NONE` or `CONTRIBUTOR`). This covers cases where the webhook payload is stale and the live issue API reports a different association, while keeping the public-route policy behavior unchanged.

--- a/.agent/src/__tests__/extract-context-cli.test.ts
+++ b/.agent/src/__tests__/extract-context-cli.test.ts
@@ -122,6 +122,61 @@ test("extract-context refreshes issue author association from the GitHub API", (
   }
 });
 
+test("extract-context refreshes contributor issue author association from the GitHub API", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
+
+  try {
+    const eventPath = join(tempDir, "event.json");
+    const outputPath = join(tempDir, "github-output.txt");
+    const fakeGh = join(tempDir, "gh");
+
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        sender: { login: "alice", type: "User" },
+        issue: {
+          number: 5,
+          title: "Investigate auth",
+          body: "@sepo-agent /answer can you investigate?",
+          html_url: "https://github.com/self-evolving/repo/issues/5",
+          node_id: "I_5",
+          author_association: "CONTRIBUTOR",
+          user: { login: "alice" },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(outputPath, "", "utf8");
+    writeFileSync(
+      fakeGh,
+      "#!/usr/bin/env bash\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"repos/self-evolving/repo/issues/5\" ]; then\n  printf 'MEMBER\\n'\n  exit 0\nfi\nprintf 'unexpected gh args: %s\\n' \"$*\" >&2\nexit 1\n",
+      { encoding: "utf8", mode: 0o755 },
+    );
+
+    execFileSync("node", [".agent/dist/cli/extract-context.js"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${tempDir}:${process.env.PATH || ""}`,
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_EVENT_NAME: "issues",
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REPOSITORY: "self-evolving/repo",
+        INPUT_MENTION: "@sepo-agent",
+        INPUT_TRIGGER_KIND: "mention",
+      },
+      stdio: "pipe",
+    });
+
+    const outputs = parseGithubOutput(outputPath);
+    assert.equal(outputs.get("should_respond"), "true");
+    assert.equal(outputs.get("association"), "MEMBER");
+    assert.equal(outputs.get("requested_route"), "answer");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("extract-context resolves label actors as OWNER for personal repositories", () => {
   const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
 

--- a/.agent/src/__tests__/extract-context-cli.test.ts
+++ b/.agent/src/__tests__/extract-context-cli.test.ts
@@ -177,6 +177,61 @@ test("extract-context refreshes contributor issue author association from the Gi
   }
 });
 
+test("extract-context preserves contributor association when refreshed issue association matches", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
+
+  try {
+    const eventPath = join(tempDir, "event.json");
+    const outputPath = join(tempDir, "github-output.txt");
+    const fakeGh = join(tempDir, "gh");
+
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        sender: { login: "alice", type: "User" },
+        issue: {
+          number: 6,
+          title: "Investigate auth",
+          body: "@sepo-agent /answer can you investigate?",
+          html_url: "https://github.com/self-evolving/repo/issues/6",
+          node_id: "I_6",
+          author_association: "CONTRIBUTOR",
+          user: { login: "alice" },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(outputPath, "", "utf8");
+    writeFileSync(
+      fakeGh,
+      "#!/usr/bin/env bash\nif [ \"$1\" = \"api\" ] && [ \"$2\" = \"repos/self-evolving/repo/issues/6\" ]; then\n  printf 'CONTRIBUTOR\\n'\n  exit 0\nfi\nprintf 'unexpected gh args: %s\\n' \"$*\" >&2\nexit 1\n",
+      { encoding: "utf8", mode: 0o755 },
+    );
+
+    execFileSync("node", [".agent/dist/cli/extract-context.js"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${tempDir}:${process.env.PATH || ""}`,
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_EVENT_NAME: "issues",
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REPOSITORY: "self-evolving/repo",
+        INPUT_MENTION: "@sepo-agent",
+        INPUT_TRIGGER_KIND: "mention",
+      },
+      stdio: "pipe",
+    });
+
+    const outputs = parseGithubOutput(outputPath);
+    assert.equal(outputs.get("should_respond"), "true");
+    assert.equal(outputs.get("association"), "CONTRIBUTOR");
+    assert.equal(outputs.get("requested_route"), "answer");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("extract-context resolves label actors as OWNER for personal repositories", () => {
   const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
 

--- a/.agent/src/cli/extract-context.ts
+++ b/.agent/src/cli/extract-context.ts
@@ -12,7 +12,6 @@ import { isKnownAuthorAssociation } from "../access-policy.js";
 import { ghApi, ghApiOk } from "../github.js";
 import { setOutput } from "../output.js";
 import {
-  DEFAULT_TRUSTED_ASSOCIATIONS,
   DEFAULT_MENTION,
   extractEventContext,
   getAuthorAssociation,
@@ -31,6 +30,11 @@ const triggerKind = String(process.env.INPUT_TRIGGER_KIND || "mention").trim().t
 const labelName = process.env.INPUT_LABEL_NAME || "";
 const authorAssociationOverride = process.env.INPUT_AUTHOR_ASSOCIATION || "";
 const repository = process.env.GITHUB_REPOSITORY || "";
+const ISSUE_ASSOCIATIONS_TRUSTED_WITHOUT_REFRESH = new Set([
+  "OWNER",
+  "MEMBER",
+  "COLLABORATOR",
+]);
 
 function hasOrgMembership(orgLogin: string, userLogin: string): boolean {
   const membershipState = ghApi([
@@ -91,14 +95,16 @@ function resolveLabelActorAssociation(payload: Record<string, any>): string {
 }
 
 function refreshIssueAssociation(association: string, issueNumber: string): string {
+  const normalized = String(association || "").trim().toUpperCase();
+
   if (
     authorAssociationOverride ||
     eventName !== "issues" ||
-    DEFAULT_TRUSTED_ASSOCIATIONS.has(association) ||
+    ISSUE_ASSOCIATIONS_TRUSTED_WITHOUT_REFRESH.has(normalized) ||
     !repository ||
     !issueNumber
   ) {
-    return association;
+    return normalized || association;
   }
 
   const refreshed = ghApi([
@@ -106,7 +112,7 @@ function refreshIssueAssociation(association: string, issueNumber: string): stri
     "--jq",
     ".author_association // empty",
   ]).toUpperCase();
-  return refreshed || association;
+  return refreshed || normalized || association;
 }
 
 if (!eventPath || !eventName) {


### PR DESCRIPTION
## Summary
- Refresh issue author associations from the GitHub API when the issue payload reports CONTRIBUTOR.
- Keeps public route policy unchanged while avoiding stale/weaker issue payloads for org members.
- Adds a regression test for issues payload CONTRIBUTOR -> REST MEMBER.

## Verification
- npm --prefix .agent ci
- npm --prefix .agent test