### PR TITLE
Fix review summary collapse bot matching

### DIFF
--- a/.agent/src/__tests__/review-summary-minimize.test.ts
+++ b/.agent/src/__tests__/review-summary-minimize.test.ts
@@ -110,6 +110,47 @@ test("collapsePreviousReviewSummaries minimizes visible generated summaries", ()
   );
 });
 
+test("collapsePreviousReviewSummaries matches GitHub App bot login variants", () => {
+  const { client, calls } = createQueuedClient([
+    { viewer: { login: "sepo-agent-app[bot]" } },
+    {
+      repository: {
+        pullRequest: {
+          comments: {
+            nodes: [
+              {
+                id: "comment-1",
+                body: "## AI Review Synthesis\n\n<!-- sepo-agent-review-synthesis -->\nold",
+                isMinimized: false,
+                author: { login: "sepo-agent-app" },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+    {
+      repository: {
+        pullRequest: {
+          reviews: {
+            nodes: [],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+    { minimizeComment: { minimizedComment: { isMinimized: true } } },
+  ]);
+
+  assert.equal(collapsePreviousReviewSummaries({
+    repo: "self-evolving/repo",
+    prNumber: 320,
+    client,
+  }), 1);
+  assert.deepEqual(calls[3]?.variables, { id: "comment-1", classifier: "OUTDATED" });
+});
+
 test("collapsePreviousReviewSummaries keeps heading fallback for markerless summaries", () => {
   const { client, calls } = createQueuedClient([
     { viewer: { login: "sepo-agent" } },

--- a/.agent/src/review-summary-minimize.ts
+++ b/.agent/src/review-summary-minimize.ts
@@ -133,9 +133,17 @@ function parseRepo(repo: string): { owner: string; name: string } {
   return { owner, name };
 }
 
+function normalizeActorLogin(login: string): string {
+  return String(login || "").trim().replace(/\[bot\]$/i, "");
+}
+
+function isSameActorLogin(left: string, right: string): boolean {
+  return normalizeActorLogin(left) === normalizeActorLogin(right);
+}
+
 function isGeneratedReviewSummary(node: ReviewSummaryNode, viewerLogin: string): boolean {
   if (!node.id || node.isMinimized) return false;
-  if ((node.author?.login || "") !== viewerLogin) return false;
+  if (!isSameActorLogin(node.author?.login || "", viewerLogin)) return false;
   return isReviewSynthesisBody(node.body || "");
 }
 


### PR DESCRIPTION
## Summary
- Normalize GitHub bot login variants when identifying prior AI review synthesis comments.
- Allows comments authored as `sepo-agent-app` to match an authenticated viewer reported as `sepo-agent-app[bot]`.
- Add a regression test for GitHub App bot login normalization.

## Verification
- npm --prefix .agent ci
- npm --prefix .agent test
