### PR TITLE
Build runtime for unsupported responses

### DIFF
--- a/.agent/docs/access-policy.md
+++ b/.agent/docs/access-policy.md
@@ -77,4 +77,4 @@ Organization membership detection depends on what the agent's GitHub token can s
 
 ## Issue-body association refresh
 
-For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before access decisions when the webhook payload reports a weaker value (for example `NONE` or `CONTRIBUTOR`). This covers cases where the webhook payload is stale and the live issue API reports a different association, while keeping the public-route policy behavior unchanged.
+For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before access decisions when the webhook payload reports a weaker value (for example `NONE` or `CONTRIBUTOR`). If the refreshed issue association is still weak, the runtime also checks the issue author with `GET /repos/{owner}/{repo}/collaborators/{username}` and treats a `204` response as `COLLABORATOR`. This covers cases where repo-scoped tokens cannot see private org membership through `author_association`, while keeping the public-route policy behavior unchanged for non-collaborators.

--- a/.agent/docs/architecture/request-lifecycle.md
+++ b/.agent/docs/architecture/request-lifecycle.md
@@ -9,7 +9,7 @@ Every trigger converges on the portal workflow `agent-router.yml`. It extracts c
 - Inline answers are posted immediately.
 - Review and `fix-pr` requests on pull requests are dispatched immediately.
 - Edited PR events are blocked from re-triggering review and `fix-pr` routes.
-- Mention and label requests that fail route authorization are posted back as inline `unsupported` replies instead of being dropped silently.
+- Mention and label requests that fail route authorization are posted back as inline `unsupported` replies instead of being dropped silently; that path still runs `Setup agent runtime` before `post-response.js` so posting dependencies are available.
 - Triaged implementation requests (i.e., when the dispatch agent predicts `implement` from a free-form mention) require an approval comment:
   - `@sepo-agent /approve req-...`
 - For triaged implementation requests from non-issue surfaces, the router drafts an issue title and body, posts the proposal on the original surface, and creates the issue after approval.

--- a/.agent/src/__tests__/envelope.test.ts
+++ b/.agent/src/__tests__/envelope.test.ts
@@ -335,6 +335,14 @@ test("agent router posts unsupported route summaries directly instead of running
     runnerWorkflow,
     /- name: Setup agent runtime[\s\S]*needs\.portal\.outputs\.route == 'answer' \|\|[\s\S]*needs\.portal\.outputs\.route == 'unsupported'/,
   );
+  assert.match(
+    runnerWorkflow,
+    /install_codex:\s*\$\{\{\s*needs\.portal\.outputs\.route == 'answer' && steps\.provider\.outputs\.install_codex \|\| 'false'\s*\}\}/,
+  );
+  assert.match(
+    runnerWorkflow,
+    /install_claude:\s*\$\{\{\s*needs\.portal\.outputs\.route == 'answer' && steps\.provider\.outputs\.install_claude \|\| 'false'\s*\}\}/,
+  );
   assert.match(runnerWorkflow, /SUMMARY:\s*\$\{\{\s*needs\.portal\.outputs\.summary\s*\}\}/);
   assert.match(runnerWorkflow, /Post unsupported response/);
   assert.match(

--- a/.agent/src/__tests__/envelope.test.ts
+++ b/.agent/src/__tests__/envelope.test.ts
@@ -331,6 +331,10 @@ test("agent router posts unsupported route summaries directly instead of running
 
   assert.match(runnerWorkflow, /Prepare unsupported response/);
   assert.match(runnerWorkflow, /needs\.portal\.outputs\.route == 'unsupported'/);
+  assert.match(
+    runnerWorkflow,
+    /- name: Setup agent runtime[\s\S]*needs\.portal\.outputs\.route == 'answer' \|\|[\s\S]*needs\.portal\.outputs\.route == 'unsupported'/,
+  );
   assert.match(runnerWorkflow, /SUMMARY:\s*\$\{\{\s*needs\.portal\.outputs\.summary\s*\}\}/);
   assert.match(runnerWorkflow, /Post unsupported response/);
   assert.match(

--- a/.agent/src/__tests__/extract-context-cli.test.ts
+++ b/.agent/src/__tests__/extract-context-cli.test.ts
@@ -177,6 +177,73 @@ test("extract-context refreshes contributor issue author association from the Gi
   }
 });
 
+test("extract-context promotes weak issue author association for repository collaborators", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
+
+  try {
+    const eventPath = join(tempDir, "event.json");
+    const outputPath = join(tempDir, "github-output.txt");
+    const fakeGh = join(tempDir, "gh");
+
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        sender: { login: "alice", type: "User" },
+        issue: {
+          number: 7,
+          title: "Investigate auth",
+          body: "@sepo-agent /answer can you investigate?",
+          html_url: "https://github.com/self-evolving/repo/issues/7",
+          node_id: "I_7",
+          author_association: "CONTRIBUTOR",
+          user: { login: "alice" },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(outputPath, "", "utf8");
+    writeFileSync(
+      fakeGh,
+      [
+        "#!/usr/bin/env bash",
+        "if [ \"$1\" = \"api\" ] && [ \"$2\" = \"repos/self-evolving/repo/issues/7\" ]; then",
+        "  printf 'CONTRIBUTOR\\n'",
+        "  exit 0",
+        "fi",
+        "if [ \"$1\" = \"api\" ] && [ \"$2\" = \"repos/self-evolving/repo/collaborators/alice\" ]; then",
+        "  exit 0",
+        "fi",
+        "printf 'unexpected gh args: %s\\n' \"$*\" >&2",
+        "exit 1",
+        "",
+      ].join("\n"),
+      { encoding: "utf8", mode: 0o755 },
+    );
+
+    execFileSync("node", [".agent/dist/cli/extract-context.js"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${tempDir}:${process.env.PATH || ""}`,
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_EVENT_NAME: "issues",
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REPOSITORY: "self-evolving/repo",
+        INPUT_MENTION: "@sepo-agent",
+        INPUT_TRIGGER_KIND: "mention",
+      },
+      stdio: "pipe",
+    });
+
+    const outputs = parseGithubOutput(outputPath);
+    assert.equal(outputs.get("should_respond"), "true");
+    assert.equal(outputs.get("association"), "COLLABORATOR");
+    assert.equal(outputs.get("requested_route"), "answer");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("extract-context preserves contributor association when refreshed issue association matches", () => {
   const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
 

--- a/.agent/src/cli/extract-context.ts
+++ b/.agent/src/cli/extract-context.ts
@@ -65,6 +65,15 @@ function hasRepositoryPermission(userLogin: string): boolean {
   return Boolean(permission) && permission !== "none";
 }
 
+function hasRepositoryCollaborator(userLogin: string): boolean {
+  const login = String(userLogin || "").trim();
+  if (!repository || !login) {
+    return false;
+  }
+
+  return ghApiOk([`repos/${repository}/collaborators/${login}`]);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function resolveLabelActorAssociation(payload: Record<string, any>): string {
   const override = String(authorAssociationOverride || "").trim().toUpperCase();
@@ -94,7 +103,11 @@ function resolveLabelActorAssociation(payload: Record<string, any>): string {
   return "NONE";
 }
 
-function refreshIssueAssociation(association: string, issueNumber: string): string {
+function refreshIssueAssociation(
+  association: string,
+  issueNumber: string,
+  issueAuthorLogin: string,
+): string {
   const normalized = String(association || "").trim().toUpperCase();
 
   if (
@@ -112,7 +125,16 @@ function refreshIssueAssociation(association: string, issueNumber: string): stri
     "--jq",
     ".author_association // empty",
   ]).toUpperCase();
-  return refreshed || normalized || association;
+  const resolved = refreshed || normalized || association;
+  if (ISSUE_ASSOCIATIONS_TRUSTED_WITHOUT_REFRESH.has(resolved)) {
+    return resolved;
+  }
+
+  if (hasRepositoryCollaborator(issueAuthorLogin)) {
+    return "COLLABORATOR";
+  }
+
+  return resolved;
 }
 
 if (!eventPath || !eventName) {
@@ -132,6 +154,7 @@ if (!eventPath || !eventName) {
       : refreshIssueAssociation(
         authorAssociationOverride || getAuthorAssociation(eventName, payload),
         String(payload.issue?.number || ""),
+        String(payload.issue?.user?.login || ""),
       );
     if (!isKnownAuthorAssociation(association)) {
       setOutput("should_respond", "false");

--- a/.github/workflows/agent-router.yml
+++ b/.github/workflows/agent-router.yml
@@ -290,7 +290,9 @@ jobs:
 
       - name: Setup agent runtime
         id: runtime
-        if: needs.portal.outputs.route == 'answer'
+        if: >-
+          needs.portal.outputs.route == 'answer' ||
+          needs.portal.outputs.route == 'unsupported'
         uses: ./.github/actions/setup-agent-runtime
         with:
           install_codex: ${{ steps.provider.outputs.install_codex }}

--- a/.github/workflows/agent-router.yml
+++ b/.github/workflows/agent-router.yml
@@ -295,8 +295,8 @@ jobs:
           needs.portal.outputs.route == 'unsupported'
         uses: ./.github/actions/setup-agent-runtime
         with:
-          install_codex: ${{ steps.provider.outputs.install_codex }}
-          install_claude: ${{ steps.provider.outputs.install_claude }}
+          install_codex: ${{ needs.portal.outputs.route == 'answer' && steps.provider.outputs.install_codex || 'false' }}
+          install_claude: ${{ needs.portal.outputs.route == 'answer' && steps.provider.outputs.install_claude || 'false' }}
 
       - name: Run answer agent
         if: needs.portal.outputs.route == 'answer'


### PR DESCRIPTION
## Summary
- Build the agent runtime before posting unsupported-route responses.
- Keeps unsupported replies direct and avoids invoking the answer agent.
- Adds workflow coverage so unsupported responses have runtime setup before calling post-response.js.

## Verification
- npm --prefix .agent ci
- npm --prefix .agent test