### PR TITLE
Promote issue authors with collaborator access

### DIFF
--- a/.agent/docs/access-policy.md
+++ b/.agent/docs/access-policy.md
@@ -77,4 +77,4 @@ Organization membership detection depends on what the agent's GitHub token can s
 
 ## Issue-body association refresh
 
-For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before access decisions when the webhook payload reports a weaker value (for example `NONE` or `CONTRIBUTOR`). This covers cases where the webhook payload is stale and the live issue API reports a different association, while keeping the public-route policy behavior unchanged.
+For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before access decisions when the webhook payload reports a weaker value (for example `NONE` or `CONTRIBUTOR`). If the refreshed issue association is still weak, the runtime also checks the issue author with `GET /repos/{owner}/{repo}/collaborators/{username}` and treats a `204` response as `COLLABORATOR`. This covers cases where repo-scoped tokens cannot see private org membership through `author_association`, while keeping the public-route policy behavior unchanged for non-collaborators.

--- a/.agent/src/__tests__/extract-context-cli.test.ts
+++ b/.agent/src/__tests__/extract-context-cli.test.ts
@@ -177,6 +177,73 @@ test("extract-context refreshes contributor issue author association from the Gi
   }
 });
 
+test("extract-context promotes weak issue author association for repository collaborators", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
+
+  try {
+    const eventPath = join(tempDir, "event.json");
+    const outputPath = join(tempDir, "github-output.txt");
+    const fakeGh = join(tempDir, "gh");
+
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        sender: { login: "alice", type: "User" },
+        issue: {
+          number: 7,
+          title: "Investigate auth",
+          body: "@sepo-agent /answer can you investigate?",
+          html_url: "https://github.com/self-evolving/repo/issues/7",
+          node_id: "I_7",
+          author_association: "CONTRIBUTOR",
+          user: { login: "alice" },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(outputPath, "", "utf8");
+    writeFileSync(
+      fakeGh,
+      [
+        "#!/usr/bin/env bash",
+        "if [ \"$1\" = \"api\" ] && [ \"$2\" = \"repos/self-evolving/repo/issues/7\" ]; then",
+        "  printf 'CONTRIBUTOR\\n'",
+        "  exit 0",
+        "fi",
+        "if [ \"$1\" = \"api\" ] && [ \"$2\" = \"repos/self-evolving/repo/collaborators/alice\" ]; then",
+        "  exit 0",
+        "fi",
+        "printf 'unexpected gh args: %s\\n' \"$*\" >&2",
+        "exit 1",
+        "",
+      ].join("\n"),
+      { encoding: "utf8", mode: 0o755 },
+    );
+
+    execFileSync("node", [".agent/dist/cli/extract-context.js"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${tempDir}:${process.env.PATH || ""}`,
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_EVENT_NAME: "issues",
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REPOSITORY: "self-evolving/repo",
+        INPUT_MENTION: "@sepo-agent",
+        INPUT_TRIGGER_KIND: "mention",
+      },
+      stdio: "pipe",
+    });
+
+    const outputs = parseGithubOutput(outputPath);
+    assert.equal(outputs.get("should_respond"), "true");
+    assert.equal(outputs.get("association"), "COLLABORATOR");
+    assert.equal(outputs.get("requested_route"), "answer");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("extract-context preserves contributor association when refreshed issue association matches", () => {
   const tempDir = mkdtempSync(join(tmpdir(), "agent-extract-context-"));
 

--- a/.agent/src/cli/extract-context.ts
+++ b/.agent/src/cli/extract-context.ts
@@ -65,6 +65,15 @@ function hasRepositoryPermission(userLogin: string): boolean {
   return Boolean(permission) && permission !== "none";
 }
 
+function hasRepositoryCollaborator(userLogin: string): boolean {
+  const login = String(userLogin || "").trim();
+  if (!repository || !login) {
+    return false;
+  }
+
+  return ghApiOk([`repos/${repository}/collaborators/${login}`]);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function resolveLabelActorAssociation(payload: Record<string, any>): string {
   const override = String(authorAssociationOverride || "").trim().toUpperCase();
@@ -94,7 +103,11 @@ function resolveLabelActorAssociation(payload: Record<string, any>): string {
   return "NONE";
 }
 
-function refreshIssueAssociation(association: string, issueNumber: string): string {
+function refreshIssueAssociation(
+  association: string,
+  issueNumber: string,
+  issueAuthorLogin: string,
+): string {
   const normalized = String(association || "").trim().toUpperCase();
 
   if (
@@ -112,7 +125,16 @@ function refreshIssueAssociation(association: string, issueNumber: string): stri
     "--jq",
     ".author_association // empty",
   ]).toUpperCase();
-  return refreshed || normalized || association;
+  const resolved = refreshed || normalized || association;
+  if (ISSUE_ASSOCIATIONS_TRUSTED_WITHOUT_REFRESH.has(resolved)) {
+    return resolved;
+  }
+
+  if (hasRepositoryCollaborator(issueAuthorLogin)) {
+    return "COLLABORATOR";
+  }
+
+  return resolved;
 }
 
 if (!eventPath || !eventName) {
@@ -132,6 +154,7 @@ if (!eventPath || !eventName) {
       : refreshIssueAssociation(
         authorAssociationOverride || getAuthorAssociation(eventName, payload),
         String(payload.issue?.number || ""),
+        String(payload.issue?.user?.login || ""),
       );
     if (!isKnownAuthorAssociation(association)) {
       setOutput("should_respond", "false");


### PR DESCRIPTION
## Summary
- When an issue event reports a weak author association, keep the existing issue-author-association refresh and add a collaborator endpoint check for the issue author.
- Promote issue authors to COLLABORATOR only when GET /repos/{owner}/{repo}/collaborators/{username} succeeds, avoiding public-read users from being trusted.
- Document the fallback and add regression coverage for the collaborator promotion path.

## Stacked on
- #12

## Verification
- npm --prefix .agent ci
- npm --prefix .agent test