### PR TITLE
Allow public contributors by default

### DIFF
--- a/.agent/docs/access-policy.md
+++ b/.agent/docs/access-policy.md
@@ -61,7 +61,9 @@ The values match GitHub's [`CommentAuthorAssociation`](https://docs.github.com/g
 If `AGENT_ACCESS_POLICY` is unset:
 
 - private repositories allow `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR`
-- public repositories allow `OWNER`, `MEMBER`, and `COLLABORATOR`
+- public repositories also allow `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR`
+
+Known limitation: GitHub can report private organization members as `CONTRIBUTOR` in public repository issue payloads when the token or payload cannot see private membership. Sepo therefore includes `CONTRIBUTOR` in the public default allowlist as a pragmatic compatibility choice. Repositories that need stricter public access should set `AGENT_ACCESS_POLICY`, for example `{"allowed_associations":["OWNER","MEMBER","COLLABORATOR"]}`.
 
 ## Enforcement model
 
@@ -77,4 +79,4 @@ Organization membership detection depends on what the agent's GitHub token can s
 
 ## Issue-body association refresh
 
-For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before access decisions when the webhook payload reports a weaker value (for example `NONE` or `CONTRIBUTOR`). If the refreshed issue association is still weak, the runtime also checks the issue author with `GET /repos/{owner}/{repo}/collaborators/{username}` and treats a `204` response as `COLLABORATOR`. This covers cases where repo-scoped tokens cannot see private org membership through `author_association`, while keeping the public-route policy behavior unchanged for non-collaborators.
+For issue-body mentions from `issues` events, the runtime refreshes `author_association` from the GitHub API before access decisions when the webhook payload reports a weaker value (for example `NONE` or `CONTRIBUTOR`). If the refreshed issue association is still weak, the runtime also checks the issue author with `GET /repos/{owner}/{repo}/collaborators/{username}` and treats a `204` response as `COLLABORATOR`. This covers some cases where repo-scoped tokens cannot see private org membership through `author_association`, but GitHub author association remains token- and visibility-dependent. The public default allowlist therefore still includes `CONTRIBUTOR` unless a repository configures a stricter `AGENT_ACCESS_POLICY`.

--- a/.agent/docs/architecture/supported-workflows.md
+++ b/.agent/docs/architecture/supported-workflows.md
@@ -86,7 +86,7 @@ Supported surfaces:
 | `discussion` | discussion title, discussion body |
 | `discussion_comment` | comment body |
 
-By default, the portal responds to `OWNER`, `MEMBER`, `COLLABORATOR`, and private-repository `CONTRIBUTOR` associations. `AGENT_ACCESS_POLICY` can tighten or widen access globally or for specific routes. Bot authors are always skipped. Implicit mentions are triaged first and then checked against the resolved route, so denied requests get a visible unsupported reply instead of being dropped silently. See [Trigger access policy](../access-policy.md).
+By default, the portal responds to `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR` associations. `AGENT_ACCESS_POLICY` can tighten or widen access globally or for specific routes; public repositories that do not want prior contributors to trigger Sepo should remove `CONTRIBUTOR` from the allowlist. Bot authors are always skipped. Implicit mentions are triaged first and then checked against the resolved route, so denied requests get a visible unsupported reply instead of being dropped silently. See [Trigger access policy](../access-policy.md).
 
 Explicit routes are:
 

--- a/.agent/docs/overview/quick-start.md
+++ b/.agent/docs/overview/quick-start.md
@@ -47,4 +47,4 @@ You can also trigger the same built-in routes with labels:
 | `agent/fix-pr` | Fix PR |
 | `agent/s/<name>` | Skill |
 
-Only authorized repository users can trigger Sepo. By default, public repositories allow `OWNER`, `MEMBER`, and `COLLABORATOR`; private repositories also allow `CONTRIBUTOR`. See [Trigger access policy](../access-policy.md) to customize that behavior.
+Only authorized repository users can trigger Sepo. By default, repositories allow `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR` associations; public repositories can tighten this with `AGENT_ACCESS_POLICY`. See [Trigger access policy](../access-policy.md) to customize that behavior.

--- a/.agent/src/__tests__/triage.test.ts
+++ b/.agent/src/__tests__/triage.test.ts
@@ -344,7 +344,7 @@ test("applyDispatchPolicy rejects routes disallowed by configured access policy"
   assert.match(d.summary, /OWNER, MEMBER, COLLABORATOR/);
 });
 
-test("applyDispatchPolicy uses collaborator-safe defaults for public repos", () => {
+test("applyDispatchPolicy allows contributors by default for public repos", () => {
   const d = applyDispatchPolicy(
     normalizeDispatch('{"route":"answer","summary":"answer it"}'),
     "issue",
@@ -352,8 +352,8 @@ test("applyDispatchPolicy uses collaborator-safe defaults for public repos", () 
     parseAccessPolicy(""),
     true,
   );
-  assert.equal(d.route, "unsupported");
-  assert.match(d.summary, /OWNER, MEMBER, COLLABORATOR/);
+  assert.equal(d.route, "answer");
+  assert.equal(d.needsApproval, false);
 });
 
 test("applyDispatchPolicy allows route overrides to widen public repo access", () => {

--- a/.agent/src/access-policy.ts
+++ b/.agent/src/access-policy.ts
@@ -22,6 +22,7 @@ const DEFAULT_PUBLIC_ALLOWED_ASSOCIATIONS = [
   "OWNER",
   "MEMBER",
   "COLLABORATOR",
+  "CONTRIBUTOR",
 ] as const;
 
 export interface AccessPolicy {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Check [Install into an existing repository](.agent/docs/deployment/install-exist
 ```
 
 > [!WARNING]
-> Only authorized repository users can trigger Sepo. By default, public repositories allow `OWNER`, `MEMBER`, and `COLLABORATOR`; private repositories also allow `CONTRIBUTOR`. See [Trigger access policy](.agent/docs/access-policy.md) to customize that behavior.
+> Only authorized repository users can trigger Sepo. By default, repositories allow `OWNER`, `MEMBER`, `COLLABORATOR`, and `CONTRIBUTOR` associations; public repositories can tighten this with `AGENT_ACCESS_POLICY`. See [Trigger access policy](.agent/docs/access-policy.md) to customize that behavior.
 
 
 ### You can also trigger the same built-in routes by adding `agent/*` labels to PRs


### PR DESCRIPTION
## Summary
- Allow CONTRIBUTOR author associations by default for public repositories.
- Document GitHub author_association limitations for public org repos and how to tighten defaults with AGENT_ACCESS_POLICY.
- Update tests/docs to match the new public default.

## Verification
- Not run per maintainer request.