### PR TITLE
Fix GitHub-hosted runner stability issues

### DIFF
--- a/.agent/docs/deployment/install-existing-repository.md
+++ b/.agent/docs/deployment/install-existing-repository.md
@@ -17,6 +17,15 @@ Copy these directories into the target repository:
 
 Copy the current `.github/` directory as a unit so the workflows, composite actions, and prompt templates stay in sync.
 
+Also merge these generated-output rules into the target repository's existing `.gitignore` without replacing target-owned entries:
+
+```gitignore
+.agent/dist/
+.agent/node_modules/
+```
+
+The workflows build `.agent/dist/` on GitHub-hosted runners before some PR checkouts. Keeping those files ignored prevents generated runtime output from being committed accidentally and keeps later fix-pr checkouts from colliding with local build products.
+
 ## Repository configuration
 
 At minimum, configure:

--- a/.agent/src/__tests__/checkout-pr-cli.test.ts
+++ b/.agent/src/__tests__/checkout-pr-cli.test.ts
@@ -1,0 +1,105 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+const repoRoot = resolve(__dirname, "../../..");
+
+function git(cwd: string, args: string[], env: NodeJS.ProcessEnv = {}): string {
+  return execFileSync("git", args, {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: "pipe",
+  }).toString("utf8").trim();
+}
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content, { encoding: "utf8", mode: 0o755 });
+}
+
+test("checkout-pr removes generated agent dist before switching to the PR branch", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "agent-checkout-pr-"));
+
+  try {
+    const remote = join(tempDir, "remote.git");
+    const seed = join(tempDir, "seed");
+    const workspace = join(tempDir, "workspace");
+    const binDir = join(tempDir, "bin");
+    const homeDir = join(tempDir, "home");
+    mkdirSync(seed, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(homeDir, { recursive: true });
+
+    git(tempDir, ["init", "--bare", remote]);
+    git(seed, ["init"]);
+    git(seed, ["config", "user.name", "Test User"]);
+    git(seed, ["config", "user.email", "test@example.com"]);
+    writeFileSync(join(seed, "README.md"), "main\n", "utf8");
+    git(seed, ["add", "README.md"]);
+    git(seed, ["commit", "-m", "initial"]);
+    git(seed, ["branch", "-M", "main"]);
+    git(seed, ["remote", "add", "origin", remote]);
+    git(seed, ["push", "-u", "origin", "main"]);
+
+    git(seed, ["checkout", "-b", "feature/generated-dist"]);
+    mkdirSync(join(seed, ".agent", "dist"), { recursive: true });
+    writeFileSync(join(seed, ".agent", "dist", "generated.js"), "tracked from pr\n", "utf8");
+    git(seed, ["add", ".agent/dist/generated.js"]);
+    git(seed, ["commit", "-m", "track generated dist"]);
+    git(seed, ["push", "origin", "feature/generated-dist"]);
+    const headOid = git(seed, ["rev-parse", "HEAD"]);
+
+    git(tempDir, ["clone", remote, workspace]);
+    git(workspace, ["checkout", "main"]);
+    mkdirSync(join(workspace, ".agent", "dist"), { recursive: true });
+    writeFileSync(join(workspace, ".agent", "dist", "generated.js"), "untracked build output\n", "utf8");
+
+    const fakeGh = join(binDir, "gh");
+    writeExecutable(fakeGh, [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      "if [[ \"$1\" == \"pr\" && \"$2\" == \"view\" ]]; then",
+      `  printf '%s\\n' ${JSON.stringify(JSON.stringify({
+        headRefName: "feature/generated-dist",
+        headRefOid: headOid,
+        isCrossRepository: false,
+        state: "OPEN",
+      }))}`,
+      "  exit 0",
+      "fi",
+      "echo unexpected gh invocation: $* >&2",
+      "exit 1",
+      "",
+    ].join("\n"));
+
+    execFileSync("git", [
+      "config",
+      "--global",
+      `url.file://${remote}.insteadOf`,
+      "https://x-access-token:token@github.com/self-evolving/repo.git",
+    ], { env: { ...process.env, HOME: homeDir }, stdio: "pipe" });
+
+    execFileSync("node", [".agent/dist/cli/checkout-pr.js"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GIT_ALLOW_PROTOCOL: "file:https",
+        GITHUB_REPOSITORY: "self-evolving/repo",
+        GITHUB_WORKSPACE: workspace,
+        GH_TOKEN: "token",
+        HOME: homeDir,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+        PR_NUMBER: "20",
+      },
+      stdio: "pipe",
+    });
+
+    assert.equal(git(workspace, ["branch", "--show-current"]), "feature/generated-dist");
+    assert.equal(readFileSync(join(workspace, ".agent", "dist", "generated.js"), "utf8"), "tracked from pr\n");
+    assert.equal(git(workspace, ["status", "--short"]), "");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/.agent/src/__tests__/checkout-pr-cli.test.ts
+++ b/.agent/src/__tests__/checkout-pr-cli.test.ts
@@ -19,87 +19,140 @@ function writeExecutable(path: string, content: string): void {
   writeFileSync(path, content, { encoding: "utf8", mode: 0o755 });
 }
 
-test("checkout-pr removes generated agent dist before switching to the PR branch", () => {
+interface CheckoutFixture {
+  binDir: string;
+  headOid: string;
+  homeDir: string;
+  remote: string;
+  tempDir: string;
+  workspace: string;
+}
+
+function createCheckoutFixture(branchName: string, setupBranch: (seed: string) => void): CheckoutFixture {
   const tempDir = mkdtempSync(join(tmpdir(), "agent-checkout-pr-"));
+  const remote = join(tempDir, "remote.git");
+  const seed = join(tempDir, "seed");
+  const workspace = join(tempDir, "workspace");
+  const binDir = join(tempDir, "bin");
+  const homeDir = join(tempDir, "home");
+  mkdirSync(seed, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(homeDir, { recursive: true });
 
-  try {
-    const remote = join(tempDir, "remote.git");
-    const seed = join(tempDir, "seed");
-    const workspace = join(tempDir, "workspace");
-    const binDir = join(tempDir, "bin");
-    const homeDir = join(tempDir, "home");
-    mkdirSync(seed, { recursive: true });
-    mkdirSync(binDir, { recursive: true });
-    mkdirSync(homeDir, { recursive: true });
+  git(tempDir, ["init", "--bare", remote]);
+  git(seed, ["init"]);
+  git(seed, ["config", "user.name", "Test User"]);
+  git(seed, ["config", "user.email", "test@example.com"]);
+  writeFileSync(join(seed, "README.md"), "main\n", "utf8");
+  writeFileSync(join(seed, ".gitignore"), ".agent/dist/\n", "utf8");
+  git(seed, ["add", "README.md", ".gitignore"]);
+  git(seed, ["commit", "-m", "initial"]);
+  git(seed, ["branch", "-M", "main"]);
+  git(seed, ["remote", "add", "origin", remote]);
+  git(seed, ["push", "-u", "origin", "main"]);
 
-    git(tempDir, ["init", "--bare", remote]);
-    git(seed, ["init"]);
-    git(seed, ["config", "user.name", "Test User"]);
-    git(seed, ["config", "user.email", "test@example.com"]);
-    writeFileSync(join(seed, "README.md"), "main\n", "utf8");
-    git(seed, ["add", "README.md"]);
-    git(seed, ["commit", "-m", "initial"]);
-    git(seed, ["branch", "-M", "main"]);
-    git(seed, ["remote", "add", "origin", remote]);
-    git(seed, ["push", "-u", "origin", "main"]);
+  git(seed, ["checkout", "-b", branchName]);
+  setupBranch(seed);
+  git(seed, ["push", "origin", branchName]);
+  const headOid = git(seed, ["rev-parse", "HEAD"]);
 
-    git(seed, ["checkout", "-b", "feature/generated-dist"]);
+  git(tempDir, ["clone", remote, workspace]);
+  git(workspace, ["checkout", "main"]);
+
+  const fakeGh = join(binDir, "gh");
+  writeExecutable(fakeGh, [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "if [[ \"$1\" == \"pr\" && \"$2\" == \"view\" ]]; then",
+    `  printf '%s\\n' ${JSON.stringify(JSON.stringify({
+      headRefName: branchName,
+      headRefOid: headOid,
+      isCrossRepository: false,
+      state: "OPEN",
+    }))}`,
+    "  exit 0",
+    "fi",
+    "echo unexpected gh invocation: $* >&2",
+    "exit 1",
+    "",
+  ].join("\n"));
+
+  execFileSync("git", [
+    "config",
+    "--global",
+    `url.file://${remote}.insteadOf`,
+    "https://x-access-token:token@github.com/self-evolving/repo.git",
+  ], { env: { ...process.env, HOME: homeDir }, stdio: "pipe" });
+
+  return { binDir, headOid, homeDir, remote, tempDir, workspace };
+}
+
+function seedBuiltRuntime(workspace: string): string {
+  const runtimeCli = join(workspace, ".agent", "dist", "cli", "post-response.js");
+  mkdirSync(join(workspace, ".agent", "dist", "cli"), { recursive: true });
+  writeFileSync(runtimeCli, "console.log('runtime ok');\n", "utf8");
+  return runtimeCli;
+}
+
+function runCheckoutPr(fixture: CheckoutFixture): void {
+  execFileSync("node", [".agent/dist/cli/checkout-pr.js"], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      GIT_ALLOW_PROTOCOL: "file:https",
+      GITHUB_REPOSITORY: "self-evolving/repo",
+      GITHUB_WORKSPACE: fixture.workspace,
+      GH_TOKEN: "token",
+      HOME: fixture.homeDir,
+      PATH: `${fixture.binDir}:${process.env.PATH || ""}`,
+      PR_NUMBER: "20",
+    },
+    stdio: "pipe",
+  });
+}
+
+test("checkout-pr force-checks out branches that accidentally track generated agent dist", () => {
+  const fixture = createCheckoutFixture("feature/generated-dist", (seed) => {
     mkdirSync(join(seed, ".agent", "dist"), { recursive: true });
     writeFileSync(join(seed, ".agent", "dist", "generated.js"), "tracked from pr\n", "utf8");
-    git(seed, ["add", ".agent/dist/generated.js"]);
+    git(seed, ["add", "-f", ".agent/dist/generated.js"]);
     git(seed, ["commit", "-m", "track generated dist"]);
-    git(seed, ["push", "origin", "feature/generated-dist"]);
-    const headOid = git(seed, ["rev-parse", "HEAD"]);
+  });
 
-    git(tempDir, ["clone", remote, workspace]);
-    git(workspace, ["checkout", "main"]);
-    mkdirSync(join(workspace, ".agent", "dist"), { recursive: true });
-    writeFileSync(join(workspace, ".agent", "dist", "generated.js"), "untracked build output\n", "utf8");
+  try {
+    mkdirSync(join(fixture.workspace, ".agent", "dist"), { recursive: true });
+    writeFileSync(join(fixture.workspace, ".agent", "dist", "generated.js"), "untracked build output\n", "utf8");
 
-    const fakeGh = join(binDir, "gh");
-    writeExecutable(fakeGh, [
-      "#!/usr/bin/env bash",
-      "set -euo pipefail",
-      "if [[ \"$1\" == \"pr\" && \"$2\" == \"view\" ]]; then",
-      `  printf '%s\\n' ${JSON.stringify(JSON.stringify({
-        headRefName: "feature/generated-dist",
-        headRefOid: headOid,
-        isCrossRepository: false,
-        state: "OPEN",
-      }))}`,
-      "  exit 0",
-      "fi",
-      "echo unexpected gh invocation: $* >&2",
-      "exit 1",
-      "",
-    ].join("\n"));
+    runCheckoutPr(fixture);
 
-    execFileSync("git", [
-      "config",
-      "--global",
-      `url.file://${remote}.insteadOf`,
-      "https://x-access-token:token@github.com/self-evolving/repo.git",
-    ], { env: { ...process.env, HOME: homeDir }, stdio: "pipe" });
-
-    execFileSync("node", [".agent/dist/cli/checkout-pr.js"], {
-      cwd: repoRoot,
-      env: {
-        ...process.env,
-        GIT_ALLOW_PROTOCOL: "file:https",
-        GITHUB_REPOSITORY: "self-evolving/repo",
-        GITHUB_WORKSPACE: workspace,
-        GH_TOKEN: "token",
-        HOME: homeDir,
-        PATH: `${binDir}:${process.env.PATH || ""}`,
-        PR_NUMBER: "20",
-      },
-      stdio: "pipe",
-    });
-
-    assert.equal(git(workspace, ["branch", "--show-current"]), "feature/generated-dist");
-    assert.equal(readFileSync(join(workspace, ".agent", "dist", "generated.js"), "utf8"), "tracked from pr\n");
-    assert.equal(git(workspace, ["status", "--short"]), "");
+    assert.equal(git(fixture.workspace, ["branch", "--show-current"]), "feature/generated-dist");
+    assert.equal(
+      readFileSync(join(fixture.workspace, ".agent", "dist", "generated.js"), "utf8"),
+      "tracked from pr\n",
+    );
+    assert.equal(git(fixture.workspace, ["status", "--short"]), "");
   } finally {
-    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("checkout-pr preserves built runtime when the PR branch does not track agent dist", () => {
+  const fixture = createCheckoutFixture("feature/no-generated-dist", (seed) => {
+    writeFileSync(join(seed, "README.md"), "feature\n", "utf8");
+    git(seed, ["add", "README.md"]);
+    git(seed, ["commit", "-m", "update readme"]);
+  });
+
+  try {
+    const runtimeCli = seedBuiltRuntime(fixture.workspace);
+
+    runCheckoutPr(fixture);
+
+    assert.equal(git(fixture.workspace, ["branch", "--show-current"]), "feature/no-generated-dist");
+    assert.equal(readFileSync(join(fixture.workspace, "README.md"), "utf8"), "feature\n");
+    assert.equal(execFileSync("node", [runtimeCli], { cwd: fixture.workspace }).toString("utf8"), "runtime ok\n");
+    assert.equal(git(fixture.workspace, ["status", "--short"]), "");
+  } finally {
+    rmSync(fixture.tempDir, { recursive: true, force: true });
   }
 });

--- a/.agent/src/__tests__/envelope.test.ts
+++ b/.agent/src/__tests__/envelope.test.ts
@@ -1055,9 +1055,11 @@ test("normal workflows honor rubrics policy instead of forcing read-only", () =>
 
 test("rubrics-review prompt chooses from full active rubric context", () => {
   const rubricsReviewPrompt = readRepoFile(".github/prompts/rubrics-review.md");
+  const rubricsReviewWorkflow = readRepoFile(".github/workflows/agent-rubrics-review.yml");
 
   assert.match(rubricsReviewPrompt, /full active rubric set/);
   assert.match(rubricsReviewPrompt, /do not score unrelated route\/process rubrics/);
+  assert.match(rubricsReviewWorkflow, /- name: Run rubrics review[\s\S]*timeout-minutes:\s*30/);
 });
 
 test("memory workflows exist and point at the right CLIs / prompts", () => {

--- a/.agent/src/__tests__/github.test.ts
+++ b/.agent/src/__tests__/github.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { dispatchWorkflow } from "../github.js";
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content, { encoding: "utf8", mode: 0o755 });
+}
+
+test("dispatchWorkflow retries without inputs unsupported by the live workflow schema", () => {
+  const tempDir = mkdtempSync(join(tmpdir(), "agent-dispatch-workflow-"));
+  const originalPath = process.env.PATH;
+
+  try {
+    const binDir = join(tempDir, "bin");
+    const payloadDir = join(tempDir, "payloads");
+    const countPath = join(tempDir, "count");
+    const logPath = join(tempDir, "gh.log");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(payloadDir, { recursive: true });
+
+    writeExecutable(join(binDir, "gh"), [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `count_path=${JSON.stringify(countPath)}`,
+      `payload_dir=${JSON.stringify(payloadDir)}`,
+      `log_path=${JSON.stringify(logPath)}`,
+      "count=0",
+      "if [[ -f \"$count_path\" ]]; then count=$(cat \"$count_path\"); fi",
+      "count=$((count + 1))",
+      "printf '%s' \"$count\" > \"$count_path\"",
+      "printf '%s\\n' \"$*\" >> \"$log_path\"",
+      "cat > \"$payload_dir/payload-$count.json\"",
+      "if [[ \"$count\" == \"1\" ]]; then",
+      "  printf '%s\\n' '{\"message\":\"Unexpected inputs provided: [\\\"target_kind\\\", \\\"access_policy\\\"]\"}'",
+      "  printf '%s\\n' 'gh: Unexpected inputs provided: [\"target_kind\", \"access_policy\"]' >&2",
+      "  exit 1",
+      "fi",
+      "exit 0",
+      "",
+    ].join("\n"));
+
+    process.env.PATH = `${binDir}:${originalPath || ""}`;
+
+    dispatchWorkflow("self-evolving/repo", "agent-orchestrator.yml", "main", {
+      access_policy: "{}",
+      source_action: "fix-pr",
+      target_kind: "pull_request",
+      target_number: "20",
+    });
+
+    const firstPayload = JSON.parse(readFileSync(join(payloadDir, "payload-1.json"), "utf8"));
+    const retryPayload = JSON.parse(readFileSync(join(payloadDir, "payload-2.json"), "utf8"));
+    const log = readFileSync(logPath, "utf8").trim().split(/\r?\n/);
+
+    assert.equal(log.length, 2);
+    assert.equal(firstPayload.inputs.target_kind, "pull_request");
+    assert.equal(firstPayload.inputs.access_policy, "{}");
+    assert.equal(retryPayload.ref, "main");
+    assert.deepEqual(retryPayload.inputs, {
+      source_action: "fix-pr",
+      target_number: "20",
+    });
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/.agent/src/cli/checkout-pr.ts
+++ b/.agent/src/cli/checkout-pr.ts
@@ -4,8 +4,6 @@
 // Outputs: head_ref, head_sha, cross_repo, pr_state
 
 import { execFileSync } from "node:child_process";
-import { rmSync } from "node:fs";
-import { join } from "node:path";
 import { setOutput } from "../output.js";
 import { fetchPrMeta } from "../github.js";
 
@@ -25,11 +23,11 @@ if (!prNumber) {
     const remoteUrl = `https://x-access-token:${token}@github.com/${repo}.git`;
     execFileSync("git", ["fetch", remoteUrl, meta.headRef], { cwd, stdio: "pipe" });
     // setup-agent-runtime builds .agent/dist before fix-pr checks out the PR
-    // branch. If that branch accidentally tracks generated dist files, Git
-    // refuses to switch because the freshly built untracked files would be
-    // overwritten. Remove only this known generated directory before checkout.
-    rmSync(join(cwd, ".agent", "dist"), { recursive: true, force: true });
-    execFileSync("git", ["checkout", "-B", meta.headRef, "FETCH_HEAD"], { cwd, stdio: "pipe" });
+    // branch. If that branch accidentally tracks generated dist files, a normal
+    // checkout refuses to overwrite the untracked build output. Force checkout
+    // only overwrites paths tracked by the target branch, while preserving the
+    // built runtime when the target branch does not track .agent/dist.
+    execFileSync("git", ["checkout", "-f", "-B", meta.headRef, "FETCH_HEAD"], { cwd, stdio: "pipe" });
     headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, stdio: "pipe" })
       .toString("utf8")
       .trim();

--- a/.agent/src/cli/checkout-pr.ts
+++ b/.agent/src/cli/checkout-pr.ts
@@ -4,6 +4,8 @@
 // Outputs: head_ref, head_sha, cross_repo, pr_state
 
 import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
 import { setOutput } from "../output.js";
 import { fetchPrMeta } from "../github.js";
 
@@ -22,6 +24,11 @@ if (!prNumber) {
   if (!meta.isCrossRepository && meta.state === "OPEN") {
     const remoteUrl = `https://x-access-token:${token}@github.com/${repo}.git`;
     execFileSync("git", ["fetch", remoteUrl, meta.headRef], { cwd, stdio: "pipe" });
+    // setup-agent-runtime builds .agent/dist before fix-pr checks out the PR
+    // branch. If that branch accidentally tracks generated dist files, Git
+    // refuses to switch because the freshly built untracked files would be
+    // overwritten. Remove only this known generated directory before checkout.
+    rmSync(join(cwd, ".agent", "dist"), { recursive: true, force: true });
     execFileSync("git", ["checkout", "-B", meta.headRef, "FETCH_HEAD"], { cwd, stdio: "pipe" });
     headSha = execFileSync("git", ["rev-parse", "HEAD"], { cwd, stdio: "pipe" })
       .toString("utf8")

--- a/.agent/src/github.ts
+++ b/.agent/src/github.ts
@@ -183,12 +183,7 @@ export function createIssue(opts: CreateIssueOptions): string {
 
 // --- Workflow dispatch ---
 
-export function dispatchWorkflow(
-  repo: string,
-  workflow: string,
-  ref: string,
-  inputs: Record<string, string>,
-): void {
+function dispatchWorkflowPayload(repo: string, workflow: string, ref: string, inputs: Record<string, string>): void {
   const payload = JSON.stringify({ ref, inputs });
   execFileSync("gh", [
     "api", "-X", "POST",
@@ -199,4 +194,47 @@ export function dispatchWorkflow(
     stdio: ["pipe", "pipe", "pipe"],
     maxBuffer: MAX_BUFFER,
   });
+}
+
+function parseUnexpectedWorkflowInputs(err: unknown): string[] {
+  const match = commandErrorText(err).match(/Unexpected inputs provided:\s*(\[[^\]]*\])/i);
+  if (!match) return [];
+  try {
+    const parsed = JSON.parse(match[1]) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((value): value is string => typeof value === "string" && value.length > 0)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function dispatchWorkflow(
+  repo: string,
+  workflow: string,
+  ref: string,
+  inputs: Record<string, string>,
+): void {
+  try {
+    dispatchWorkflowPayload(repo, workflow, ref, inputs);
+    return;
+  } catch (err: unknown) {
+    const unexpectedInputs = parseUnexpectedWorkflowInputs(err);
+    if (unexpectedInputs.length === 0) throw err;
+
+    const retryInputs = { ...inputs };
+    let removed = 0;
+    for (const name of unexpectedInputs) {
+      if (Object.prototype.hasOwnProperty.call(retryInputs, name)) {
+        delete retryInputs[name];
+        removed += 1;
+      }
+    }
+    if (removed === 0) throw err;
+
+    console.warn(
+      `Retrying ${workflow} dispatch without unsupported input(s): ${unexpectedInputs.join(", ")}`,
+    );
+    dispatchWorkflowPayload(repo, workflow, ref, retryInputs);
+  }
 }

--- a/.github/workflows/agent-rubrics-review.yml
+++ b/.github/workflows/agent-rubrics-review.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Run rubrics review
         id: review
         continue-on-error: true
+        timeout-minutes: 30
         uses: ./.github/actions/run-agent-task
         with:
           agent: ${{ steps.provider.outputs.provider }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.agent/node_modules/
 .agent/dist/
 .claude/worktrees/
 .desloppify/

--- a/.skills/install-agent/SKILL.md
+++ b/.skills/install-agent/SKILL.md
@@ -56,6 +56,9 @@ unless explicitly requested.
 - Do not copy generated or local-only files: `node_modules/`, `dist/`,
   `.agent/node_modules/`, `.agent/dist/`, `.git/`, `_worktrees/`, or
   `.claude/worktrees/`.
+- Merge agent-generated-output ignore rules into the target's existing
+  `.gitignore` instead of replacing it: at least `.agent/dist/` and
+  `.agent/node_modules/`.
 - Do not ask users to paste secrets into issues, PRs, comments, or committed
   files. Direct them to GitHub settings or `gh secret set` in a trusted shell.
 
@@ -86,6 +89,9 @@ unless explicitly requested.
 
 4. Copy the install files conservatively.
    - Sync `.agent/` with generated/dependency exclusions.
+   - Preserve target-owned root files, but add the agent ignore entries
+     `.agent/dist/` and `.agent/node_modules/` to the target `.gitignore` if
+     missing so GitHub-hosted runner builds do not leak generated files into PRs.
    - Copy all source `.github/` files/directories into the target `.github/` by
      default, but merge rather than wholesale replace.
    - Preserve target-only `.github` files and replace existing `.github` files


### PR DESCRIPTION
## Summary

Fix the GitHub-hosted runner failures seen after migration by removing assumptions that held on persistent/self-hosted workspaces.

- Clean generated `.agent/dist/` before `checkout-pr` switches to a PR head so tracked generated files on a PR branch cannot block checkout.
- Retry workflow dispatch once without inputs rejected by the live workflow schema, which keeps automation handoffs resilient while workflow input schemas roll out.
- Add a 30-minute timeout to advisory rubrics review agent runs so a hung model call cannot hold the whole review workflow for GitHub's six-hour default.
- Document and enforce generated-output ignore rules for installs: `.agent/dist/` and `.agent/node_modules/`.

## Investigation notes

Observed failures this addresses:

1. PR #7 review looked unfinished because the advisory rubrics-review job stayed alive until GitHub's default six-hour timeout. The actual dual review and synthesis completed and posted, but the overall workflow stayed pending/cancelled because rubrics review never returned.
2. PR #20 fix-pr completed its code changes, then failed while dispatching the follow-up review because the PR-branch runtime sent newly added workflow inputs to the default-branch workflow schema, which rejected them with `Unexpected inputs provided`.
3. The downstream docs-site fix-pr run failed before the agent could start because setup built `.agent/dist/`, then `checkout-pr` tried to switch to a PR branch that had accidentally committed `.agent/dist`; Git refused to overwrite the untracked build output.

## Validation

- `npm --prefix .agent ci`
- `npm --prefix .agent test` — passed (`377/377`)
- `git diff --check`
- workflow/action/template YAML parsed with Ruby `YAML.load_file`
- shell syntax checks for installed agent scripts/actions
