### PR TITLE
chore: remove trailing whitespace from agent assets

### DIFF
--- a/.agent/docs/customization/configuration-list.md
+++ b/.agent/docs/customization/configuration-list.md
@@ -28,7 +28,7 @@ The bundled workflows intentionally expose one global provider variable. If a re
 
 | Secret | Purpose |
 |---|---|
-| Model provider secrets | | 
+| Model provider secrets | |
 | `OPENAI_API_KEY` | Enable Codex-backed runs on runners without local Codex authentication; also lets `AGENT_DEFAULT_PROVIDER=auto` detect Codex |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Enable Claude-backed runs on runners without local Claude authentication; also lets `AGENT_DEFAULT_PROVIDER=auto` detect Claude |
 | GitHub auth secrets |  |

--- a/.agent/src/reactions.ts
+++ b/.agent/src/reactions.ts
@@ -31,4 +31,3 @@ export function addReaction(subjectId: string, content: string): void {
     { stdio: "pipe", maxBuffer: MAX_BUFFER },
   );
 }
-

--- a/.github/prompts/_base.md
+++ b/.github/prompts/_base.md
@@ -1,6 +1,6 @@
 You are the Sepo agent running in a GitHub Actions workflow on the `${REPO_SLUG}` repository.
 
-## Context 
+## Context
 
 Repository: `${REPO_SLUG}`
 Target: ${TARGET_KIND} #${TARGET_NUMBER}
@@ -9,7 +9,7 @@ URL: ${TARGET_URL}
 Requested by: ${REQUESTED_BY}
 Request: ${REQUEST_TEXT}
 
-## General guidelines 
+## General guidelines
 
 - Before starting, check for broader project context:
   - Read the target for references to parent issues, tracking issues, or project plans (e.g., "Parent: #24", "Part of #24").
@@ -20,7 +20,7 @@ Request: ${REQUEST_TEXT}
   - For discussions: `node .agent/dist/cli/fetch-discussion-transcript.js ${TARGET_NUMBER}`
   - Use the local checkout and repository files as the primary source of truth for the current code state
   - Avoid broad searches through generated/vendor directories like `.git/`, `node_modules/`, `.agent/node_modules/`, `dist/`, and `.agent/dist/` unless the task is specifically about them
-- Since you are running inside a github action, there are a few other differences compared to directly interacting with users: 
-  - You have full permission to run commands given it's a sandbox environment.  
-  - When you draft a message and when you want to refer to files, please use links for github files rather than local file references. 
+- Since you are running inside a github action, there are a few other differences compared to directly interacting with users:
+  - You have full permission to run commands given it's a sandbox environment.
+  - When you draft a message and when you want to refer to files, please use links for github files rather than local file references.
   - Do not run destructive cleanup commands as there are followup steps that handle this.

--- a/.github/prompts/agent-dispatch.md
+++ b/.github/prompts/agent-dispatch.md
@@ -1,11 +1,11 @@
 ## Task Description
 
-The user mentioned the agent on GitHub and your task is to infer user intention and triage to specific routes: 
+The user mentioned the agent on GitHub and your task is to infer user intention and triage to specific routes:
 
 The message that mentioned the agent:
 ${MENTION_BODY}
 
-## Instruction 
+## Instruction
 
 Choose exactly one route:
 - `answer`: answer inline now
@@ -34,7 +34,7 @@ Rules:
 - Use `review` only when the user is explicitly asking for a PR review or another review pass.
 - Use `create-action` when the user asks to create an automatically running or durable automation, monitor, scheduled job, or recurring check.
 - Use `answer` for questions, clarification, lightweight analysis, or discussion.
-  - Sometimes the user may also ask the agent to review some code (and the user could be explicit about just review and launch a review agent). In this case, we should also resolve to `answer`.  
+  - Sometimes the user may also ask the agent to review some code (and the user could be explicit about just review and launch a review agent). In this case, we should also resolve to `answer`.
 - Use `unsupported` when the user asks for a workflow this repo does not support yet.
 - `fix-pr` is only valid for `pull_request` targets. If the request is not on a pull request, use `unsupported`.
 - Keep `summary` short and user-facing.

--- a/.github/prompts/agent-implement.md
+++ b/.github/prompts/agent-implement.md
@@ -3,7 +3,7 @@
 Implement GitHub issue #${TARGET_NUMBER}.
 
 Instructions:
-1. Start by reading the current issue state with `gh issue view ${TARGET_NUMBER} --repo ${REPO_SLUG} --json title,body,author,comments,labels,state,url`. Please also check the broader project context. 
+1. Start by reading the current issue state with `gh issue view ${TARGET_NUMBER} --repo ${REPO_SLUG} --json title,body,author,comments,labels,state,url`. Please also check the broader project context.
 2. Make the smallest complete change that resolves the issue.
 3. Run lightweight, directly relevant checks when they are clearly applicable.
 4. Do not commit. Leave changes in the working tree.


### PR DESCRIPTION
## Summary

Remove the minimal set of trailing whitespace / extra EOF whitespace currently causing downstream `git diff --check` verification failures after syncing `.agent/` and `.github/` from upstream.

## Changes

- Trim trailing whitespace in affected docs and prompt templates.
- Remove one extra blank line at EOF in `.agent/src/reactions.ts`.
- No behavior changes.

## Validation

- `git diff --check`
