### PR TITLE
Document deploy-safe agent committer identity

### DIFF
--- a/.agent/docs/customization/configuration-list.md
+++ b/.agent/docs/customization/configuration-list.md
@@ -19,8 +19,17 @@
 | `AGENT_RUBRICS_POLICY` | JSON policy controlling which routes can read or write user/team rubrics. Defaults to read-only. See [User/team rubrics](../architecture/rubrics.md). |
 | `AGENT_RUBRICS_REF` | Default branch name used when workflows mount user/team rubrics. Defaults to `agent/rubrics`. |
 | `AGENT_RUBRICS_LIMIT` | Maximum selected rubrics injected into an agent prompt. Defaults to `10`. |
-| `AGENT_COMMITTER_NAME` | Custom commit author name for implementation and PR-fix runs |
-| `AGENT_COMMITTER_EMAIL` | Custom commit author email for implementation and PR-fix runs |
+| `AGENT_COMMITTER_NAME` | Custom commit author name for implementation and PR-fix runs. Useful when downstream deploy providers require commits to be authored by a team member. |
+| `AGENT_COMMITTER_EMAIL` | Custom commit author email for implementation and PR-fix runs. For GitHub noreply identities, use the exact email shown in the user's GitHub email settings. |
+
+### Commit author identity for deploy providers
+
+Some deploy providers, including Vercel projects with Git author protection enabled, only create deployments for commits whose author maps to a user with access to the deployment project. If agent-authored commits are blocked with a message such as `Git author sepo-agent must have access to the project on Vercel`, set these repository variables to a Vercel project member's GitHub identity:
+
+- `AGENT_COMMITTER_NAME`
+- `AGENT_COMMITTER_EMAIL`
+
+This changes the author on implementation and PR-fix commits while leaving the GitHub authentication token unchanged.
 
 The bundled workflows intentionally expose one global provider variable. If a repository needs a route-specific provider, edit that route's `resolve-agent-provider` step in the workflow YAML and set `default_provider` or `route_provider` inline. The review workflow still launches explicit Claude and Codex reviewer lanes; `AGENT_DEFAULT_PROVIDER` controls the single synthesis step that combines whatever review artifacts were produced.
 

--- a/.agent/docs/deployment/install-existing-repository.md
+++ b/.agent/docs/deployment/install-existing-repository.md
@@ -35,6 +35,8 @@ At minimum, configure:
 
 See [Setup guide](setup-guide.md) for the auth options and trade-offs.
 
+If this repository is connected to Vercel or another deploy provider that restricts deploys by Git author, also configure `AGENT_COMMITTER_NAME` and `AGENT_COMMITTER_EMAIL` as repository variables for an allowed deploy-project member. See [Commit author identity](setup-guide.md#commit-author-identity) for details.
+
 ## First verification
 
 After the files and secrets are in place:

--- a/.agent/docs/deployment/setup-guide.md
+++ b/.agent/docs/deployment/setup-guide.md
@@ -62,6 +62,17 @@ If you use a fine-grained PAT, start with these repository permissions:
 - **Discussions:** read and write, only if you use discussion triggers
 - **Actions:** read and write, for approval dispatch and review artifact flows
 
+## Commit author identity
+
+Sepo's implementation and PR-fix workflows create commits with the `sepo-agent` author by default. That is usually fine for GitHub, but some deployment providers apply author-based deployment protection. For example, Vercel can reject a deployment with an error like `Git author sepo-agent must have access to the project on Vercel`.
+
+For repositories connected to such deploy providers, configure these repository variables so agent commits use a GitHub identity that already has access to the deployment project:
+
+- `AGENT_COMMITTER_NAME`
+- `AGENT_COMMITTER_EMAIL`
+
+Use the exact Git author name and email that the provider maps to the allowed user. For GitHub noreply addresses, copy the noreply email from the user's GitHub email settings. This only changes commit author metadata; GitHub API authentication still follows the auth priority above.
+
 ## Workflow token fallback
 
 If no higher-priority auth mode is configured, the backend can still fall back to `github.token`. This is useful as a lowest-friction fallback, but it should not be treated as the preferred long-term setup for more advanced automation.


### PR DESCRIPTION
## Summary
- document AGENT_COMMITTER_NAME and AGENT_COMMITTER_EMAIL as the fix for deploy providers that restrict deployments by Git author
- add a setup-guide section for Vercel's "Git author sepo-agent must have access" failure mode
- mention the variables in the install-existing-repository flow

## Test
- npm --prefix .agent run build