### PR TITLE
Allow project-manager agent commands

### DIFF
--- a/.github/workflows/agent-project-manager.yml
+++ b/.github/workflows/agent-project-manager.yml
@@ -159,7 +159,7 @@ jobs:
           github_token: ${{ steps.auth.outputs.token }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
           claude_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          permission_mode: approve-reads
+          permission_mode: approve-all
           prompt: project-manager
           route: answer
           memory_mode_override: disabled


### PR DESCRIPTION
## Summary
- Change the project-manager agent step from `permission_mode: approve-reads` to `permission_mode: approve-all`
- This lets the existing project-manager prompt run its `gh issue list` and `gh pr list` reads without interactive approval prompts

## Context
Follow-up from PR #39 after the project-manager run failed because the agent tried to call GitHub list commands under `approve-reads`: https://github.com/self-evolving/repo/pull/39#issuecomment-4348139723

## Verification
- `npm --prefix .agent test`