### PR TITLE
Use project-management discussion category for daily summaries

### DIFF
--- a/.agent/docs/customization/configuration-list.md
+++ b/.agent/docs/customization/configuration-list.md
@@ -16,7 +16,7 @@
 | `AGENT_PROJECT_MANAGEMENT_DRY_RUN` | Defaults project-management runs to dry-run mode. Defaults to `true`; set to `false` with label application enabled to apply validated managed-label plans. |
 | `AGENT_PROJECT_MANAGEMENT_APPLY_LABELS` | Set to `true` to allow the deterministic post-agent step to update managed `priority/*` and `effort/*` labels when dry-run mode is disabled. |
 | `AGENT_PROJECT_MANAGEMENT_POST_SUMMARY` | Set to `true` to have the final workflow step comment with the project-management summary on today's existing Daily Summary discussion. If the discussion is missing, only the Actions step summary is written. |
-| `AGENT_PROJECT_MANAGEMENT_DISCUSSION_CATEGORY` | Discussion category where Daily Summary discussions are posted. Defaults to `General`. |
+| `AGENT_PROJECT_MANAGEMENT_DISCUSSION_CATEGORY` | Discussion category shared by Daily Summary discussion creation and project-management summary comments. Defaults to `General`. |
 | `AGENT_PROJECT_MANAGEMENT_LIMIT` | Maximum open issues and pull requests for the agent to inspect per kind. Defaults to `100`. |
 | `AGENT_ACCESS_POLICY` | JSON trigger allowlist policy. See [Trigger access policy](../access-policy.md). |
 | `AGENT_MEMORY_POLICY` | JSON policy controlling which routes can read or write repository memory. See [Repository memory](../architecture/memory.md). |

--- a/.agent/src/__tests__/envelope.test.ts
+++ b/.agent/src/__tests__/envelope.test.ts
@@ -210,6 +210,11 @@ test("scheduled workflows evaluate skip gates before provider-dependent jobs", (
   assert.doesNotMatch(dailySummaryWorkflow, /COMMIT_COUNT/);
   assert.match(dailySummaryWorkflow, /count=\$\(\(ISSUE_COUNT \+ PULL_COUNT \+ DISCUSSION_COUNT\)\)/);
   assert.match(dailySummaryWorkflow, /Resolve daily summary provider[\s\S]*Setup selected provider/);
+  assert.match(dailySummaryWorkflow, /discussion_category:[\s\S]*default:\s*""/);
+  assert.match(
+    dailySummaryWorkflow,
+    /DISCUSSION_CATEGORY:\s*\$\{\{\s*inputs\.discussion_category \|\| vars\.AGENT_PROJECT_MANAGEMENT_DISCUSSION_CATEGORY \|\| 'General'\s*\}\}/,
+  );
   assert.doesNotMatch(dailySummaryWorkflow, /if: steps\.pre_gate\.outputs\.skip != 'true' && steps\.gate\.outputs\.skip != 'true'/);
 });
 

--- a/.github/workflows/agent-daily-summary.yml
+++ b/.github/workflows/agent-daily-summary.yml
@@ -10,9 +10,9 @@ on:
         required: false
         default: "1"
       discussion_category:
-        description: "Discussion category for posted summaries"
+        description: "Discussion category for posted summaries. Defaults to AGENT_PROJECT_MANAGEMENT_DISCUSSION_CATEGORY or General."
         required: false
-        default: "General"
+        default: ""
 
 permissions:
   actions: read
@@ -138,7 +138,7 @@ jobs:
     if: needs.signals.result == 'success' && needs.signals.outputs.skip != 'true'
     runs-on: ${{ fromJson(vars.AGENT_RUNS_ON || '["ubuntu-latest"]') }}
     env:
-      DISCUSSION_CATEGORY: ${{ inputs.discussion_category || 'General' }}
+      DISCUSSION_CATEGORY: ${{ inputs.discussion_category || vars.AGENT_PROJECT_MANAGEMENT_DISCUSSION_CATEGORY || 'General' }}
       LOOKBACK_DAYS: ${{ inputs.lookback_days || '1' }}
       SIGNALS_DIR: daily-signals
     steps:


### PR DESCRIPTION
## Summary
- Let daily summaries default to AGENT_PROJECT_MANAGEMENT_DISCUSSION_CATEGORY before falling back to General
- Keep manual workflow overrides by leaving the discussion_category input blank by default
- Document the shared category variable and add workflow regression coverage

## Verification
- npm --prefix .agent test