### PR TITLE
Add simplified Sepo version metadata foundation

### DIFF
--- a/.agent/docs/README.md
+++ b/.agent/docs/README.md
@@ -18,6 +18,7 @@
 - [Key concepts](technical-details/key-concepts.md)
 - [Session continuity](technical-details/session-continuity.md)
 - [Agent orchestrator](technical-details/agent-orchestrator.md)
+- [Sepo versioning](technical-details/versioning.md)
 - [Developer notes](technical-details/developer-notes.md)
 
 ## Actions

--- a/.agent/docs/deployment/install-existing-repository.md
+++ b/.agent/docs/deployment/install-existing-repository.md
@@ -26,6 +26,18 @@ Also merge these generated-output rules into the target repository's existing `.
 
 The workflows build `.agent/dist/` on GitHub-hosted runners. Keeping generated runtime outputs ignored prevents them from being committed accidentally.
 
+## Sepo version metadata
+
+Keep `.agent/sepo-version.json` with the copied `.agent/` tree. It records the
+installed Sepo version, source repository/ref, optional exact source SHA,
+install source kind, and optional installed-file hash. See [Sepo versioning](../technical-details/versioning.md)
+for the schema and SemVer policy.
+
+For release installs, prefer a release tag in `source_ref` such as `v0.1.0` and
+record the exact source commit in `source_sha`. For moving-branch development
+installs, `source_ref` may be `main` or `develop` and `source_sha` may stay
+`null` until install/update tooling records the exact checkout SHA.
+
 ## Repository configuration
 
 At minimum, configure:

--- a/.agent/docs/deployment/setup-guide.md
+++ b/.agent/docs/deployment/setup-guide.md
@@ -2,6 +2,11 @@
 
 There are two main customization points: how GitHub authentication is resolved, and where the workflows run.
 
+Sepo installations also include `.agent/sepo-version.json`, which records the
+installed Sepo version and source identity. Keep that file with `.agent/` when
+copying or updating an installation. See [Sepo versioning](../technical-details/versioning.md)
+for the SemVer policy and metadata fields.
+
 ## Supported GitHub auth paths
 
 | Path | Best when | What you configure |

--- a/.agent/docs/technical-details/versioning.md
+++ b/.agent/docs/technical-details/versioning.md
@@ -1,0 +1,47 @@
+# Sepo Versioning
+
+Sepo uses SemVer for public version labels.
+
+## Policy
+
+- Use `v0.x.y` tags while the install, update, and bug-report contract is still pre-release.
+- Bump the `0.x` minor version for meaningful agent or workflow changes.
+- Bump the `0.x` patch version for bugfix-only releases.
+- Use `v1.0.0-rc.N` only when the public contract is frozen and the release is truly a candidate for `v1.0.0`.
+- Use `v1.0.0` for the first public stable release.
+
+The metadata version omits the leading `v` so it remains plain SemVer and can stay aligned with `.agent/package.json`. Git tags and release refs include the leading `v`, for example `v0.1.0`.
+
+## Installed metadata
+
+Every Sepo install carries `.agent/sepo-version.json`:
+
+```json
+{
+  "schema_version": 1,
+  "version": "0.1.0",
+  "channel": "pre-release",
+  "source_repo": "self-evolving/repo",
+  "source_ref": "main",
+  "source_sha": null,
+  "installed_from": "source",
+  "agent_files_hash": null
+}
+```
+
+Fields:
+
+| Field | Meaning |
+|---|---|
+| `schema_version` | Metadata schema version, currently `1`. |
+| `version` | Sepo SemVer string without a leading `v`. |
+| `channel` | `pre-release`, `release-candidate`, or `stable`. |
+| `source_repo` | GitHub `owner/repo` slug used as the Sepo source. |
+| `source_ref` | Branch, tag, or ref used by the install. Release installs should use a tag such as `v0.1.0`. |
+| `source_sha` | Exact source commit SHA when known; use `null` for moving-branch installs until tooling records an exact SHA. |
+| `installed_from` | `source`, `release`, `template`, `manual-copy`, or `update`. |
+| `agent_files_hash` | Optional `sha256:<hex>` digest for installed agent-owned files; `null` means no digest has been recorded yet. |
+
+This separates the user-facing Sepo version from the exact source identity. A fork or copied install can keep saying which Sepo line it started from while later tooling can add the exact commit and file hash when available.
+
+Future update, bug-report, or release workflows can add a small reader/CLI when they need to consume this metadata directly.

--- a/.agent/sepo-version.json
+++ b/.agent/sepo-version.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "version": "0.1.0",
+  "channel": "pre-release",
+  "source_repo": "self-evolving/repo",
+  "source_ref": "main",
+  "source_sha": null,
+  "installed_from": "source",
+  "agent_files_hash": null
+}


### PR DESCRIPTION
## Summary
- Add a committed `.agent/sepo-version.json` install metadata file.
- Document Sepo SemVer policy and installed source-identity fields.
- Update setup/install docs to tell users to keep the metadata file with `.agent/`.

This is a minimal alternative to #128 for #127 / #74. It intentionally does not add a reader, CLI, validation library, tests, updater rewriting, bug-report integration, or release workflows yet. Those can be added in the later PRs that actually consume the metadata.

## Tests
- `python3 -m json.tool .agent/sepo-version.json >/dev/null`
- `git diff --check`