### PR TITLE
Rename docs nav root label

### DIFF
--- a/.agent/docs/_meta.json
+++ b/.agent/docs/_meta.json
@@ -1,5 +1,5 @@
 {
-  "label": "Doc Index",
+  "label": "self-evolving/repo",
   "pages": [
     "overview",
     "architecture",


### PR DESCRIPTION
## Summary
- rename the root docs navigation label from `Doc Index` to `self-evolving/repo` in `.agent/docs/_meta.json`

## Validation
- JSON-only label change