### PR TITLE
Avoid duplicate model flags for session runs

### DIFF
--- a/.agent/src/__tests__/acpx-adapter.test.ts
+++ b/.agent/src/__tests__/acpx-adapter.test.ts
@@ -42,9 +42,10 @@ test("buildAcpxArgs puts global flags before the agent token for exec routes", (
   ]);
 });
 
-test("buildAcpxArgs uses prompt mode with a named session for persistent routes", () => {
+test("buildAcpxArgs omits the global model flag for named sessions", () => {
   const args = buildAcpxArgs({
     agent: "claude",
+    model: "claude-sonnet-4-5",
     prompt: "apply the requested fix",
     permissionMode: "approve-all",
     sessionName: "pull_request-38-fix-pr-default",
@@ -156,6 +157,7 @@ if (args.includes("prompt")) {
 
     const result = runAcpx({
       agent: "codex",
+      model: "gpt-5.4",
       prompt: "synthesize current artifacts",
       cwd: process.cwd(),
       sessionMode: sessionModeForPolicy("track-only"),
@@ -179,6 +181,7 @@ if (args.includes("prompt")) {
 
     assert.deepEqual(calls.map((call) => call.args), [
       ["codex", "sessions", "new", "--name", sessionName],
+      ["codex", "set", "model", "gpt-5.4", "-s", sessionName],
       ["codex", "set", "-s", sessionName, "thought_level", "xhigh"],
       ["codex", "set-mode", "-s", sessionName, "full-access"],
       [

--- a/.agent/src/__tests__/acpx-adapter.test.ts
+++ b/.agent/src/__tests__/acpx-adapter.test.ts
@@ -45,7 +45,7 @@ test("buildAcpxArgs puts global flags before the agent token for exec routes", (
 test("buildAcpxArgs omits the global model flag for named sessions", () => {
   const args = buildAcpxArgs({
     agent: "claude",
-    model: "claude-sonnet-4-5",
+    model: "claude-opus-4-7",
     prompt: "apply the requested fix",
     permissionMode: "approve-all",
     sessionName: "pull_request-38-fix-pr-default",
@@ -157,7 +157,7 @@ if (args.includes("prompt")) {
 
     const result = runAcpx({
       agent: "codex",
-      model: "gpt-5.4",
+      model: "gpt-5.5",
       prompt: "synthesize current artifacts",
       cwd: process.cwd(),
       sessionMode: sessionModeForPolicy("track-only"),
@@ -181,7 +181,7 @@ if (args.includes("prompt")) {
 
     assert.deepEqual(calls.map((call) => call.args), [
       ["codex", "sessions", "new", "--name", sessionName],
-      ["codex", "set", "model", "gpt-5.4", "-s", sessionName],
+      ["codex", "set", "model", "gpt-5.5", "-s", sessionName],
       ["codex", "set", "-s", sessionName, "thought_level", "xhigh"],
       ["codex", "set-mode", "-s", sessionName, "full-access"],
       [

--- a/.agent/src/acpx-adapter.ts
+++ b/.agent/src/acpx-adapter.ts
@@ -239,7 +239,8 @@ export function buildAcpxArgs(options: {
     args.push("--timeout", String(options.timeout));
   }
   const model = options.model?.trim();
-  if (model) {
+  const usesNamedSession = !options.isExecRoute && Boolean(options.sessionName);
+  if (model && !usesNamedSession) {
     args.push("--model", model);
   }
 


### PR DESCRIPTION
Summary:
- Use session setup as the single model-selection path for named ACPX sessions.
- Keep global `--model` on no-session exec commands.
- Add coverage for persistent and transient session command construction.

Testing:
- from the package directory: `npm ci`
- from the package directory: `npm run build`
- from the package directory: `node --test dist/__tests__/acpx-adapter.test.js`
- from the package directory: `npm test`
- `git diff --check`

Closes #342
