### PR TITLE
Normalize Codex ACP model reasoning

### DIFF
--- a/.agent/docs/customization/configuration-list.md
+++ b/.agent/docs/customization/configuration-list.md
@@ -53,6 +53,8 @@ title: "Configurations list"
 }
 ```
 
+For Codex GPT-5 models, Sepo accepts provider-neutral `model` plus `reasoning_effort` policy entries and passes the effective ACP model id to acpx. For example, `{ "model": "gpt-5.5", "reasoning_effort": "xhigh" }` is sent to Codex ACP as `gpt-5.5/xhigh`, matching the model ids advertised by the bundled `@zed-industries/codex-acp` adapter. If a Codex model already includes an effort suffix such as `gpt-5.5/xhigh`, Sepo treats that model id as authoritative and does not send a separate `thought_level` setting. Claude and unknown/custom Codex model ids keep using the separate reasoning-effort path.
+
 The bundled workflows still keep native YAML escape hatches: an inline `route_provider` in a workflow's `resolve-agent-provider` step overrides `AGENT_MODEL_POLICY` for that route. Provider selection precedence is inline `route_provider`, then `AGENT_MODEL_POLICY.route_overrides[route].provider`, then `AGENT_DEFAULT_PROVIDER`, then `auto` detection from configured provider secrets. The review workflow still launches explicit Claude and Codex reviewer lanes; model policy applies to the single synthesis step that combines produced review artifacts, not to the reviewer lane matrix.
 
 ## Repository secrets

--- a/.agent/package-lock.json
+++ b/.agent/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@self-evolving/sepo",
       "version": "0.3.0",
       "dependencies": {
+        "@zed-industries/codex-acp": "0.15.0",
         "acpx": "^0.6.1",
         "yaml": "^2.8.3"
       },
@@ -470,6 +471,119 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp/-/codex-acp-0.15.0.tgz",
+      "integrity": "sha512-eAv7sGBeiYrYkOulF729nrM51szS7WIhBtugRj5wWq6csRKZUhAZfoUZlF8xUWdHPtOIzd/eT6MNG6gMHu6z0w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex-acp": "bin/codex-acp.js"
+      },
+      "optionalDependencies": {
+        "@zed-industries/codex-acp-darwin-arm64": "0.15.0",
+        "@zed-industries/codex-acp-darwin-x64": "0.15.0",
+        "@zed-industries/codex-acp-linux-arm64": "0.15.0",
+        "@zed-industries/codex-acp-linux-x64": "0.15.0",
+        "@zed-industries/codex-acp-win32-arm64": "0.15.0",
+        "@zed-industries/codex-acp-win32-x64": "0.15.0"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-darwin-arm64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-arm64/-/codex-acp-darwin-arm64-0.15.0.tgz",
+      "integrity": "sha512-9/tnj1fXeXIONgr+5FGwr3bkqd4jaORdr3X9/k++rzHW+UIzvgIeXrJKv43403gtuKp0BoxdzsFxe2qsAQhhkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "codex-acp-darwin-arm64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-darwin-x64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-x64/-/codex-acp-darwin-x64-0.15.0.tgz",
+      "integrity": "sha512-2cmflnVYM5yzvNu4ldff6OsfLzQThFToPszCT3t7jytWuG28V+W1cUEGsvFJGNkGC1Wo29Z4w5LZ3wyfOkvPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "codex-acp-darwin-x64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-linux-arm64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-arm64/-/codex-acp-linux-arm64-0.15.0.tgz",
+      "integrity": "sha512-ioCXCiZMd4v7Eqyed9Iz4xcPKsZbSH157wOitsWQKxUiX43c1Ti5fykZcrh9cNSLOgiGmI3V2nbYp0aTf66grQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "codex-acp-linux-arm64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-linux-x64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-x64/-/codex-acp-linux-x64-0.15.0.tgz",
+      "integrity": "sha512-WtqI8KGX9z7XvdkazumYraoDwpip5lFBRtFXoIwYCSBoDZdOqQsfNQndIfTDttfQ1BdZYKczDnrfbRaiIFU9UA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "codex-acp-linux-x64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-win32-arm64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-arm64/-/codex-acp-win32-arm64-0.15.0.tgz",
+      "integrity": "sha512-L+OFIPOzAuxsImlq8E227MZxgujMLMEJSqiR9QjZq8fiIFCKh/HnxmvyXvjWaHbJdb1pZ09WKe3MNwV9ln/+GQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "codex-acp-win32-arm64": "bin/codex-acp.exe"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-win32-x64": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-x64/-/codex-acp-win32-x64-0.15.0.tgz",
+      "integrity": "sha512-LDnADpCg1Rzbkyxs4hMaOvRwNa68KLp8CoNVom8ZE/sChSvcDrj/RCoMsZWrARJGWs7EQ9zYeLoeVk5VcVQoPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "codex-acp-win32-x64": "bin/codex-acp.exe"
       }
     },
     "node_modules/acpx": {

--- a/.agent/package.json
+++ b/.agent/package.json
@@ -9,6 +9,7 @@
     "test": "npm run build && node --test $(find dist -name '*.test.js' -type f | sort) $(find scripts -path '*/test/*.test.cjs' -type f | sort)"
   },
   "dependencies": {
+    "@zed-industries/codex-acp": "0.15.0",
     "acpx": "^0.6.1",
     "yaml": "^2.8.3"
   },

--- a/.agent/src/__tests__/acpx-adapter.test.ts
+++ b/.agent/src/__tests__/acpx-adapter.test.ts
@@ -11,6 +11,7 @@ import {
   extractAssistantText,
   parseSessionIdentity,
   readSessionIdentityResult,
+  resolveAcpxModelSelection,
   runAcpx,
   runCommandWithFileCapture,
   selectPromptForSessionOutcome,
@@ -89,7 +90,36 @@ test("buildAcpxArgs passes model as a global acpx flag before the agent", () => 
   ]);
 });
 
-test("buildSessionSetupCommands uses acpx set model for named sessions", () => {
+test("resolveAcpxModelSelection folds GPT-5 Codex reasoning into the model id", () => {
+  assert.deepEqual(
+    resolveAcpxModelSelection({ agent: "codex", model: "gpt-5.5", thoughtLevel: "xhigh" }),
+    { model: "gpt-5.5/xhigh", thoughtLevel: undefined, reasoningEncodedInModel: true },
+  );
+
+  assert.deepEqual(
+    resolveAcpxModelSelection({ agent: "codex", model: "gpt-5.5/high", thoughtLevel: "xhigh" }),
+    { model: "gpt-5.5/high", thoughtLevel: undefined, reasoningEncodedInModel: true },
+  );
+
+  assert.deepEqual(
+    resolveAcpxModelSelection({ agent: "codex", model: "gpt-5.5[xhigh]", thoughtLevel: "high" }),
+    { model: "gpt-5.5[xhigh]", thoughtLevel: undefined, reasoningEncodedInModel: true },
+  );
+});
+
+test("resolveAcpxModelSelection keeps non-Codex and unknown Codex reasoning separate", () => {
+  assert.deepEqual(
+    resolveAcpxModelSelection({ agent: "claude", model: "claude-opus-4-8", thoughtLevel: "max" }),
+    { model: "claude-opus-4-8", thoughtLevel: "max", reasoningEncodedInModel: false },
+  );
+
+  assert.deepEqual(
+    resolveAcpxModelSelection({ agent: "codex", model: "o3", thoughtLevel: "high" }),
+    { model: "o3", thoughtLevel: "high", reasoningEncodedInModel: false },
+  );
+});
+
+test("buildSessionSetupCommands encodes Codex model reasoning for named sessions", () => {
   const commands = buildSessionSetupCommands({
     agent: "codex",
     sessionName: "pull_request-38-fix-pr-default",
@@ -99,8 +129,7 @@ test("buildSessionSetupCommands uses acpx set model for named sessions", () => {
   });
 
   assert.deepEqual(commands.map((command) => command.args), [
-    ["codex", "set", "model", "gpt-5.4", "-s", "pull_request-38-fix-pr-default"],
-    ["codex", "set", "-s", "pull_request-38-fix-pr-default", "thought_level", "xhigh"],
+    ["codex", "set", "model", "gpt-5.4/xhigh", "-s", "pull_request-38-fix-pr-default"],
     ["codex", "set-mode", "-s", "pull_request-38-fix-pr-default", "full-access"],
   ]);
 });
@@ -127,11 +156,10 @@ test("buildAcpxArgs keeps track-only synthesis in exec mode without a named sess
   assert.equal(args.includes("-s"), false);
 });
 
-test("runAcpx preserves Codex thought level for track-only exec without stable session reuse", () => {
+test("runAcpx encodes GPT-5 Codex thought level into the exec model id", () => {
   const dir = mkdtempSync(join(tmpdir(), "acpx-track-only-test-"));
   const oldPath = process.env.PATH;
   const threadKey = "self-evolving/repo:pull_request:268:review:synthesize";
-  const stableSessionName = sessionNameFromThreadKey(threadKey);
 
   try {
     const acpxPath = join(dir, "acpx");
@@ -142,9 +170,9 @@ test("runAcpx preserves Codex thought level for track-only exec without stable s
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.ACPX_TEST_CALLS, JSON.stringify({ args }) + "\\n");
-if (args.includes("prompt")) {
+if (args.includes("exec")) {
   process.stdout.write([
-    '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"sess-track-only","models":{"currentModelId":"gpt-5.4"}}}',
+    '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"sess-track-only","models":{"currentModelId":"gpt-5.5/xhigh"}}}',
     '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Done."}}}}',
     '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
   ].join("\\n") + "\\n");
@@ -169,35 +197,26 @@ if (args.includes("prompt")) {
 
     assert.equal(result.exitCode, 0);
     assert.equal(result.stdout, "Done.");
-    assert.equal(result.sessionEnsureOutcome.kind, "fresh");
-    assert.match(result.sessionName ?? "", /^pull_request-268-review-synthesize-exec-[0-9a-f]{12}$/);
-    assert.notEqual(result.sessionName, stableSessionName);
+    assert.equal(result.sessionEnsureOutcome.kind, "not_applicable");
+    assert.equal(result.sessionName, undefined);
 
-    const sessionName = result.sessionName!;
     const calls = readFileSync(callsPath, "utf8")
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line) as { args: string[] });
 
-    assert.deepEqual(calls.map((call) => call.args), [
-      ["codex", "sessions", "new", "--name", sessionName],
-      ["codex", "set", "model", "gpt-5.5", "-s", sessionName],
-      ["codex", "set", "-s", sessionName, "thought_level", "xhigh"],
-      ["codex", "set-mode", "-s", sessionName, "full-access"],
-      [
-        "--approve-all",
-        "--format",
-        "json",
-        "--json-strict",
-        "--suppress-reads",
-        "codex",
-        "prompt",
-        "-s",
-        sessionName,
-        "synthesize current artifacts",
-      ],
-    ]);
-    assert.equal(calls.some((call) => call.args.includes(stableSessionName)), false);
+    assert.deepEqual(calls.map((call) => call.args), [[
+      "--approve-all",
+      "--format",
+      "json",
+      "--json-strict",
+      "--suppress-reads",
+      "--model",
+      "gpt-5.5/xhigh",
+      "codex",
+      "exec",
+      "synthesize current artifacts",
+    ]]);
   } finally {
     if (oldPath === undefined) {
       delete process.env.PATH;

--- a/.agent/src/acpx-adapter.ts
+++ b/.agent/src/acpx-adapter.ts
@@ -93,6 +93,9 @@ const CLAUDE_BYPASS_MODE = "bypassPermissions";
 const DEFAULT_PERMISSION_MODE: PermissionMode = "approve-all";
 const ACPX_MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
 const TRANSIENT_EXEC_SESSION_BYTES = 6;
+const CODEX_REASONING_EFFORTS = new Set(["low", "medium", "high", "xhigh"]);
+const CODEX_REASONING_SUFFIX = /(?:\/(?:low|medium|high|xhigh)|\[(?:low|medium|high|xhigh)\])$/u;
+const CODEX_REASONING_MODEL_PREFIX = /^gpt-5(?:[.-]|$)/u;
 
 export interface FileCaptureRunOptions {
   command: string;
@@ -220,6 +223,66 @@ function isCodexAgent(agent: string): boolean {
   return agent.trim().toLowerCase() === "codex";
 }
 
+export interface AcpxModelSelection {
+  model?: string;
+  thoughtLevel?: string;
+  reasoningEncodedInModel: boolean;
+}
+
+/**
+ * Normalizes Sepo's provider-neutral `model` + `reasoning_effort` fields into
+ * the model ids advertised by newer Codex ACP adapters.
+ *
+ * `@zed-industries/codex-acp` reports GPT-5 Codex reasoning variants as model
+ * ids such as `gpt-5.5/xhigh`. Sending `model=gpt-5.5` and then setting
+ * `thought_level=xhigh` no longer replays reliably for named sessions, so Sepo
+ * composes those values before handing them to acpx. Non-Codex agents and
+ * Codex requests without a known GPT-5 reasoning variant keep the legacy
+ * separate thought-level path.
+ */
+export function resolveAcpxModelSelection(options: {
+  agent: string;
+  model?: string;
+  thoughtLevel?: string;
+}): AcpxModelSelection {
+  const model = options.model?.trim() || "";
+  const thoughtLevel = options.thoughtLevel?.trim() || "";
+
+  if (!isCodexAgent(options.agent) || !model) {
+    return {
+      model: model || undefined,
+      thoughtLevel: thoughtLevel || undefined,
+      reasoningEncodedInModel: false,
+    };
+  }
+
+  if (CODEX_REASONING_SUFFIX.test(model)) {
+    return {
+      model,
+      thoughtLevel: undefined,
+      reasoningEncodedInModel: true,
+    };
+  }
+
+  if (
+    thoughtLevel &&
+    CODEX_REASONING_EFFORTS.has(thoughtLevel) &&
+    CODEX_REASONING_MODEL_PREFIX.test(model)
+  ) {
+    return {
+      model: `${model}/${thoughtLevel}`,
+      thoughtLevel: undefined,
+      reasoningEncodedInModel: true,
+    };
+  }
+
+  return {
+    model,
+    thoughtLevel: thoughtLevel || undefined,
+    reasoningEncodedInModel: false,
+  };
+}
+
 export function buildAcpxArgs(options: {
   agent: string;
   model?: string;
@@ -292,12 +355,16 @@ export function buildSessionSetupCommands(options: {
   }
 
   const normalizedAgent = options.agent.trim().toLowerCase();
+  const modelSelection = resolveAcpxModelSelection({
+    agent: options.agent,
+    model: options.model,
+    thoughtLevel: options.thoughtLevel,
+  });
   const commands: SessionSetupCommand[] = [];
-  const model = options.model?.trim();
-  if (model) {
+  if (modelSelection.model) {
     commands.push({
       label: "set model",
-      args: [options.agent, "set", "model", model, "-s", options.sessionName],
+      args: [options.agent, "set", "model", modelSelection.model, "-s", options.sessionName],
     });
   }
 
@@ -311,7 +378,7 @@ export function buildSessionSetupCommands(options: {
     return commands;
   }
 
-  const thoughtLevel = options.thoughtLevel?.trim();
+  const thoughtLevel = modelSelection.thoughtLevel;
   if (thoughtLevel) {
     commands.push({
       label: "set thought_level",
@@ -675,10 +742,12 @@ export function runAcpx(options: AcpxRunOptions): AcpxRunResult {
   const permissionMode = options.permissionMode ?? DEFAULT_PERMISSION_MODE;
   const isExecRoute = sessionMode === "exec";
   const env = { ...process.env, ...extraEnv };
-  const normalizedThoughtLevel = thoughtLevel?.trim();
+  const modelSelection = resolveAcpxModelSelection({ agent, model, thoughtLevel });
+  const selectedModel = modelSelection.model;
+  const selectedThoughtLevel = modelSelection.thoughtLevel;
   const needsTransientExecSession =
     preserveExecSession === true ||
-    (isExecRoute && isCodexAgent(agent) && Boolean(normalizedThoughtLevel));
+    (isExecRoute && isCodexAgent(agent) && Boolean(selectedThoughtLevel));
   let sessionName: string | undefined;
   let sessionEnsureOutcome: SessionEnsureOutcome = { kind: "not_applicable" };
   if (isExecRoute && needsTransientExecSession) {
@@ -698,8 +767,8 @@ export function runAcpx(options: AcpxRunOptions): AcpxRunResult {
     const setupResult = runSessionSetupCommands({
       agent,
       sessionName,
-      model,
-      thoughtLevel: normalizedThoughtLevel,
+      model: selectedModel,
+      thoughtLevel: selectedThoughtLevel,
       permissionMode,
       cwd,
       env,
@@ -735,8 +804,8 @@ export function runAcpx(options: AcpxRunOptions): AcpxRunResult {
     const setupResult = runSessionSetupCommands({
       agent,
       sessionName,
-      model,
-      thoughtLevel,
+      model: selectedModel,
+      thoughtLevel: selectedThoughtLevel,
       permissionMode,
       cwd,
       env,
@@ -755,7 +824,7 @@ export function runAcpx(options: AcpxRunOptions): AcpxRunResult {
   }
   const args = buildAcpxArgs({
     agent,
-    model,
+    model: selectedModel,
     prompt: selectPromptForSessionOutcome({
       fullPrompt: prompt,
       continuationPrompt,


### PR DESCRIPTION
## Summary
- Pin `@zed-industries/codex-acp@0.15.0` as a project-local runtime dependency so `acpx@0.6.1` launches an adapter that advertises GPT-5.5 reasoning variants.
- Normalize Codex GPT-5 `model + reasoning_effort` inputs into ACP model ids like `gpt-5.5/xhigh` before calling acpx.
- Avoid the broken GPT-5.5 flow of `set model gpt-5.5` followed by `set thought_level xhigh`; preserve the legacy separate thought-level path for Claude and unknown/custom Codex models.
- Document the Codex model naming behavior.

## Tests
- `cd .agent && npm test`
- Local smoke: `.agent/node_modules/.bin/acpx --model gpt-5.5/xhigh codex exec ...` selected `codex-acp 0.15.0` and `currentModelId=gpt-5.5/xhigh` before timing out/auth failing.

Stack foundation for superseding #380 and #387.
