### PR TITLE
Bundle model defaults in .agent/model-defaults.json (simpler alternative to #393)

### DIFF
--- a/.agent/docs/customization/configuration-list.md
+++ b/.agent/docs/customization/configuration-list.md
@@ -38,14 +38,14 @@ title: "Configurations list"
 | `AGENT_COMMITTER_NAME` | Custom commit author name for implementation and PR-fix runs |
 | `AGENT_COMMITTER_EMAIL` | Custom commit author email for implementation and PR-fix runs |
 
-Built-in model defaults are intentionally small and pinned:
+Bundled model defaults live in `.agent/model-defaults.json` and are intentionally small and pinned:
 
 | Provider | Default model |
 |---|---|
 | `codex` | `gpt-5.5` |
 | `claude` | `claude-opus-4-8` |
 
-Sepo does not maintain a general model catalog. Use `AGENT_MODEL_POLICY` when a repository needs different models, route-specific choices, or reasoning effort overrides.
+Sepo does not maintain a general model catalog, and the resolver reads these defaults from the bundled file locally with no network access at run time. Updates to the file ship through `agent-update.yml` with the rest of `.agent/`. Use `AGENT_MODEL_POLICY` when a repository needs different models, route-specific choices, or reasoning effort overrides.
 
 `AGENT_MODEL_POLICY` example:
 

--- a/.agent/model-defaults.json
+++ b/.agent/model-defaults.json
@@ -1,0 +1,14 @@
+{
+  "providers": {
+    "codex": {
+      "default": {
+        "model": "gpt-5.5"
+      }
+    },
+    "claude": {
+      "default": {
+        "model": "claude-opus-4-8"
+      }
+    }
+  }
+}

--- a/.agent/src/__tests__/envelope.test.ts
+++ b/.agent/src/__tests__/envelope.test.ts
@@ -361,6 +361,7 @@ test("single-agent workflows resolve provider before runtime setup", () => {
   assert.doesNotMatch(resolverAction, /display_model:/);
   assert.match(resolverImplementation, /DEFAULT_PROVIDER/);
   assert.match(resolverImplementation, /AGENT_MODEL_POLICY/);
+  assert.match(resolverImplementation, /\.agent\/model-defaults\.json/);
   assert.match(resolverImplementation, /OPENAI_API_KEY/);
   assert.match(resolverImplementation, /CLAUDE_CODE_OAUTH_TOKEN/);
   assert.match(resolverImplementation, /ANTHROPIC_API_KEY/);

--- a/.agent/src/__tests__/resolve-agent-provider.test.ts
+++ b/.agent/src/__tests__/resolve-agent-provider.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -132,6 +140,48 @@ test("provider resolver loads bundled provider model defaults", () => {
   assert.equal(claude.outputs.provider, "claude");
   assert.equal(claude.outputs.model, "claude-opus-4-8");
   assert.equal(claude.outputs.reasoning_effort, "");
+});
+
+test("provider resolver fails when a bundled provider default is missing", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "agent-provider-defaults-"));
+  const outputFile = path.join(tempDir, "github-output");
+
+  try {
+    // Recreate the action directory layout so the resolver's relative
+    // ../../../.agent/model-defaults.json path resolves inside the temp tree.
+    const actionDir = path.join(tempDir, ".github/actions/resolve-agent-provider");
+    mkdirSync(actionDir, { recursive: true });
+    const scopedResolver = path.join(actionDir, "resolve-provider.js");
+    copyFileSync(resolverScript, scopedResolver);
+
+    mkdirSync(path.join(tempDir, ".agent"), { recursive: true });
+    writeFileSync(
+      path.join(tempDir, ".agent/model-defaults.json"),
+      JSON.stringify({ providers: { codex: { default: { model: "gpt-5.5" } } } }),
+    );
+
+    const result = spawnSync(process.execPath, [scopedResolver], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputFile,
+        ROUTE: "test-route",
+        ROUTE_PROVIDER: "",
+        DEFAULT_PROVIDER: "claude",
+        OPENAI_API_KEY: "",
+        CLAUDE_CODE_OAUTH_TOKEN: "",
+        ANTHROPIC_API_KEY: "",
+        REQUIRED: "true",
+        AGENT_MODEL_POLICY: "",
+      },
+    });
+
+    assert.equal(result.status, 1, result.stdout + result.stderr);
+    assert.match(result.stderr, /providers\.claude\.default\.model/);
+    assert.equal(parseOutputs(outputFile).model, undefined);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("provider resolver honors default and inline route overrides", () => {

--- a/.agent/src/__tests__/resolve-agent-provider.test.ts
+++ b/.agent/src/__tests__/resolve-agent-provider.test.ts
@@ -114,7 +114,7 @@ test("provider resolver auto-detects configured providers deterministically", ()
   assert.equal(bothClaudeCredentials.outputs.install_claude, "true");
 });
 
-test("provider resolver pins built-in provider model defaults", () => {
+test("provider resolver loads bundled provider model defaults", () => {
   const codex = runResolver({
     DEFAULT_PROVIDER: "codex",
   });

--- a/.github/actions/resolve-agent-provider/resolve-provider.js
+++ b/.github/actions/resolve-agent-provider/resolve-provider.js
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 
 const fs = require("node:fs");
+const path = require("node:path");
 
 const VALID_PROVIDERS = new Set(["auto", "codex", "claude"]);
 const VALID_ROUTE_KEY = /^[a-z0-9][a-z0-9._-]*$/;
 const SAFE_TOKEN = /^[A-Za-z0-9][A-Za-z0-9._:/+-]*$/;
-// Keep this small: Sepo pins one default model per supported provider, not a model catalog.
-const BUILTIN_PROVIDER_DEFAULTS = Object.freeze({
-  codex: Object.freeze({ model: "gpt-5.5" }),
-  claude: Object.freeze({ model: "claude-opus-4-8" }),
-});
+// Keep this small: Sepo ships one default model per supported provider in
+// .agent/model-defaults.json, not a model catalog. The file is bundled and
+// refreshed through agent-update.yml with the rest of .agent/, so provider
+// resolution stays offline and deterministic with no network fetch.
+const BUNDLED_MODEL_DEFAULTS_PATH = path.resolve(__dirname, "../../../.agent/model-defaults.json");
 
 function normalizeProvider(value) {
   return String(value || "").trim().toLowerCase();
@@ -166,9 +167,29 @@ function resolveProviderRequest(env, policy, route) {
   return { requestedProvider, requestedReason, hasRouteProviderOverride: Boolean(routeProvider) };
 }
 
-function resolveRunConfig(policy, provider, route, options = {}) {
+function loadModelDefaults() {
+  const payload = JSON.parse(fs.readFileSync(BUNDLED_MODEL_DEFAULTS_PATH, "utf8"));
+  const providers =
+    payload && typeof payload === "object" && !Array.isArray(payload) ? payload.providers : undefined;
+  if (!providers || typeof providers !== "object" || Array.isArray(providers)) {
+    throw new Error("model-defaults.json must define a providers object");
+  }
+  const defaults = {};
+  for (const provider of ["codex", "claude"]) {
+    const model = normalizeOptionalToken(
+      providers[provider]?.default?.model,
+      `model-defaults.json providers.${provider}.default.model`,
+    );
+    if (model) {
+      defaults[provider] = { model };
+    }
+  }
+  return defaults;
+}
+
+function resolveRunConfig(policy, modelDefaults, provider, route, options = {}) {
   const config = { model: "", reasoningEffort: "" };
-  applyRunConfig(config, BUILTIN_PROVIDER_DEFAULTS[provider] || {});
+  applyRunConfig(config, modelDefaults[provider] || {});
   applyRunConfig(config, policy.defaultConfig);
   applyRunConfig(config, policy.providers[provider] || {});
   if (!options.hasRouteProviderOverride) {
@@ -241,7 +262,8 @@ function main(env) {
     );
   }
 
-  const runConfig = resolveRunConfig(policy, provider, route, { hasRouteProviderOverride });
+  const modelDefaults = loadModelDefaults();
+  const runConfig = resolveRunConfig(policy, modelDefaults, provider, route, { hasRouteProviderOverride });
   writeOutputs({
     provider,
     reason,

--- a/.github/actions/resolve-agent-provider/resolve-provider.js
+++ b/.github/actions/resolve-agent-provider/resolve-provider.js
@@ -180,9 +180,10 @@ function loadModelDefaults() {
       providers[provider]?.default?.model,
       `model-defaults.json providers.${provider}.default.model`,
     );
-    if (model) {
-      defaults[provider] = { model };
+    if (!model) {
+      throw new Error(`model-defaults.json must define a non-empty providers.${provider}.default.model`);
     }
+    defaults[provider] = { model };
   }
   return defaults;
 }


### PR DESCRIPTION
## Summary
Moves Sepo's pinned per-provider default models out of the hardcoded `BUILTIN_PROVIDER_DEFAULTS` object in `resolve-provider.js` and into a bundled `.agent/model-defaults.json` that the resolver reads locally. Resolved models are unchanged (`gpt-5.5` / `claude-opus-4-8`); precedence stays `bundled defaults < AGENT_MODEL_POLICY`. The loader requires a non-empty default for both supported providers and fails loudly if the bundled file is malformed.

## Why a new PR (vs #393)
#393 implements the same data-file idea but adds a **layered remote registry**: every `resolve-agent-provider` run also fetches `raw.githubusercontent.com/self-evolving/repo/main/.agent/model-defaults.json`, with a hand-rolled http/https client, a strict validator, a `model_source` output, and fallback. That puts a network round-trip on the hot path of **every** agent run (3× per review, uncached) just to close the gap *between* `agent-update.yml` runs.

But `agent-update.yml` already syncs `.agent/` (including this file) to installed repos on its ~biweekly schedule and on demand, as a reviewed PR — and it bumps the model default together with the matching runtime/adapter version. A live per-run fetch bypasses that review and can push a model id a repo's installed runtime can't run.

So this PR keeps the good half of #393 (defaults as data) and drops the remote layer:
- no per-run network / latency / rate-limit exposure
- no remote fetch, http client, registry validator, or `model_source` plumbing
- model + runtime updates stay coupled and reviewed via agent-update

## Resolution of #392 / #393
This **supersedes #393** and intentionally **rescopes #392**: after weighing the remote-registry design, we're settling on the simpler bundled-only approach. #392's remote-registry acceptance criteria (`AGENT_MODEL_REGISTRY*`, per-run fetch + fallback) are deliberately dropped, because `agent-update.yml` already delivers `.agent/` updates to installed repos as a reviewed, runtime-coupled PR. This PR closes #392 as resolved by the bundled-only design.

Closes #392.

## Verification
- `cd .agent && npm run build`
- `cd .agent && node --test dist/__tests__/resolve-agent-provider.test.js dist/__tests__/envelope.test.js dist/__tests__/docs-validation.test.js` — 92 pass
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)