### PR TITLE
Pin Claude ACPX models via ANTHROPIC_MODEL (fix resume crash on date-pinned IDs)

### DIFF
--- a/.agent/CHANGELOG.md
+++ b/.agent/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-
-- Claude ACPX runs now pin date/version model IDs (for example `claude-opus-4-8`) through the Claude Agent SDK's `ANTHROPIC_MODEL` environment variable instead of acpx's `--model` / `set model` flags. The Claude ACP adapter advertises only aliases (`opus`/`sonnet`/`haiku`), so a pinned ID failed acpx's advertised-model validation and crashed on session resume; selecting it via the environment applies the exact model on new and resumed sessions alike. Advertised aliases continue to flow through acpx unchanged.
-
 ## 0.3.1 - 2026-06-04
 
 ### Fixed

--- a/.agent/CHANGELOG.md
+++ b/.agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Claude ACPX runs now pin date/version model IDs (for example `claude-opus-4-8`) through the Claude Agent SDK's `ANTHROPIC_MODEL` environment variable instead of acpx's `--model` / `set model` flags. The Claude ACP adapter advertises only aliases (`opus`/`sonnet`/`haiku`), so a pinned ID failed acpx's advertised-model validation and crashed on session resume; selecting it via the environment applies the exact model on new and resumed sessions alike. Advertised aliases continue to flow through acpx unchanged.
+
 ## 0.3.1 - 2026-06-04
 
 ### Fixed

--- a/.agent/src/__tests__/acpx-adapter.test.ts
+++ b/.agent/src/__tests__/acpx-adapter.test.ts
@@ -6,6 +6,7 @@ import { delimiter, join } from "node:path";
 
 import {
   buildAcpxArgs,
+  buildClaudePinnedModelEnv,
   buildSessionSetupCommands,
   compactSessionLog,
   extractAssistantText,
@@ -88,6 +89,67 @@ test("buildAcpxArgs passes model as a global acpx flag before the agent", () => 
     "exec",
     "answer this",
   ]);
+});
+
+test("buildAcpxArgs omits --model for pinned Claude IDs (delivered via ANTHROPIC_MODEL)", () => {
+  const args = buildAcpxArgs({
+    agent: "claude",
+    model: "claude-opus-4-8",
+    prompt: "answer this",
+    permissionMode: "approve-all",
+    isExecRoute: true,
+  });
+
+  assert.equal(args.includes("--model"), false);
+  assert.deepEqual(args, [
+    "--approve-all",
+    "--format",
+    "json",
+    "--json-strict",
+    "--suppress-reads",
+    "claude",
+    "exec",
+    "answer this",
+  ]);
+});
+
+test("buildAcpxArgs keeps --model for advertised Claude aliases", () => {
+  const args = buildAcpxArgs({
+    agent: "claude",
+    model: "opus",
+    prompt: "answer this",
+    permissionMode: "approve-all",
+    isExecRoute: true,
+  });
+
+  assert.deepEqual(args.slice(5, 7), ["--model", "opus"]);
+});
+
+test("buildClaudePinnedModelEnv pins date/version Claude IDs via ANTHROPIC_MODEL", () => {
+  assert.deepEqual(buildClaudePinnedModelEnv({ agent: "claude", model: "claude-opus-4-8", env: {} }), {
+    ANTHROPIC_MODEL: "claude-opus-4-8",
+  });
+  // The 1M-context suffix is preserved.
+  assert.deepEqual(
+    buildClaudePinnedModelEnv({ agent: "claude", model: "claude-opus-4-8[1m]", env: {} }),
+    { ANTHROPIC_MODEL: "claude-opus-4-8[1m]" },
+  );
+});
+
+test("buildClaudePinnedModelEnv ignores aliases, non-Claude agents, and preset overrides", () => {
+  // Advertised alias → acpx applies it directly, no env pin.
+  assert.deepEqual(buildClaudePinnedModelEnv({ agent: "claude", model: "opus", env: {} }), {});
+  // Non-Claude agent keeps its normal model handling.
+  assert.deepEqual(buildClaudePinnedModelEnv({ agent: "codex", model: "gpt-5.5", env: {} }), {});
+  // An operator-set ANTHROPIC_MODEL is left untouched.
+  assert.deepEqual(
+    buildClaudePinnedModelEnv({
+      agent: "claude",
+      model: "claude-opus-4-8",
+      env: { ANTHROPIC_MODEL: "claude-sonnet-4-6" },
+    }),
+    {},
+  );
 });
 
 test("resolveAcpxModelSelection folds GPT-5 Codex reasoning into the model id", () => {
@@ -512,6 +574,111 @@ test("buildSessionSetupCommands skips claude setup when not approve-all", () => 
   });
 
   assert.deepEqual(commands, []);
+});
+
+test("buildSessionSetupCommands omits `set model` for pinned Claude IDs", () => {
+  const commands = buildSessionSetupCommands({
+    agent: "claude",
+    sessionName: "issue-71-implement-default",
+    model: "claude-opus-4-8",
+    permissionMode: "approve-all",
+  });
+
+  // No `set model` (it would fail acpx validation on resume) — only the mode.
+  // The model is applied via ANTHROPIC_MODEL instead.
+  assert.deepEqual(commands, [
+    {
+      label: "set-mode",
+      args: ["claude", "set-mode", "-s", "issue-71-implement-default", "bypassPermissions"],
+    },
+  ]);
+});
+
+test("buildSessionSetupCommands keeps `set model` for advertised Claude aliases", () => {
+  const commands = buildSessionSetupCommands({
+    agent: "claude",
+    sessionName: "issue-71-implement-default",
+    model: "opus",
+    permissionMode: "approve-all",
+  });
+
+  assert.deepEqual(commands, [
+    {
+      label: "set model",
+      args: ["claude", "set", "model", "opus", "-s", "issue-71-implement-default"],
+    },
+    {
+      label: "set-mode",
+      args: ["claude", "set-mode", "-s", "issue-71-implement-default", "bypassPermissions"],
+    },
+  ]);
+});
+
+test("runAcpx pins Claude model via ANTHROPIC_MODEL and omits the acpx model flag", () => {
+  const dir = mkdtempSync(join(tmpdir(), "acpx-claude-pin-test-"));
+  const oldPath = process.env.PATH;
+  const oldModel = process.env.ANTHROPIC_MODEL;
+  delete process.env.ANTHROPIC_MODEL;
+
+  try {
+    const acpxPath = join(dir, "acpx");
+    const callsPath = join(dir, "calls.jsonl");
+    writeFileSync(
+      acpxPath,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(
+  process.env.ACPX_TEST_CALLS,
+  JSON.stringify({ args, anthropicModel: process.env.ANTHROPIC_MODEL ?? null }) + "\\n",
+);
+if (args.includes("exec")) {
+  process.stdout.write([
+    '{"jsonrpc":"2.0","id":1,"result":{"sessionId":"sess-claude-pin"}}',
+    '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Done."}}}}',
+    '{"jsonrpc":"2.0","id":2,"result":{"stopReason":"end_turn"}}'
+  ].join("\\n") + "\\n");
+}
+`,
+      "utf8",
+    );
+    chmodSync(acpxPath, 0o755);
+    process.env.PATH = `${dir}${delimiter}${oldPath || ""}`;
+
+    const result = runAcpx({
+      agent: "claude",
+      model: "claude-opus-4-8",
+      prompt: "answer this",
+      cwd: process.cwd(),
+      sessionMode: "exec",
+      permissionMode: "approve-all",
+      env: { ACPX_TEST_CALLS: callsPath },
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, "Done.");
+
+    const calls = readFileSync(callsPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { args: string[]; anthropicModel: string | null });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].args.includes("--model"), false);
+    assert.equal(calls[0].anthropicModel, "claude-opus-4-8");
+  } finally {
+    if (oldPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = oldPath;
+    }
+    if (oldModel === undefined) {
+      delete process.env.ANTHROPIC_MODEL;
+    } else {
+      process.env.ANTHROPIC_MODEL = oldModel;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("extractAssistantText returns the last message from a compacted log", () => {

--- a/.agent/src/acpx-adapter.ts
+++ b/.agent/src/acpx-adapter.ts
@@ -96,6 +96,10 @@ const TRANSIENT_EXEC_SESSION_BYTES = 6;
 const CODEX_REASONING_EFFORTS = new Set(["low", "medium", "high", "xhigh"]);
 const CODEX_REASONING_SUFFIX = /(?:\/(?:low|medium|high|xhigh)|\[(?:low|medium|high|xhigh)\])$/u;
 const CODEX_REASONING_MODEL_PREFIX = /^gpt-5(?:[.-]|$)/u;
+// Date/version-pinned Claude model IDs (e.g. "claude-opus-4-8" or
+// "claude-opus-4-8[1m]"), as opposed to adapter-advertised aliases such as
+// "opus"/"sonnet"/"haiku".
+const CLAUDE_PINNED_MODEL_PATTERN = /^claude-[A-Za-z0-9._-]+(?:\[[A-Za-z0-9._-]+\])?$/u;
 
 export interface FileCaptureRunOptions {
   command: string;
@@ -223,6 +227,43 @@ function isCodexAgent(agent: string): boolean {
   return agent.trim().toLowerCase() === "codex";
 }
 
+function isClaudeAgent(agent: string): boolean {
+  return agent.trim().toLowerCase() === "claude";
+}
+
+/**
+ * Claude ACP advertises models as aliases ("opus", "sonnet", ...), not
+ * date/version-pinned IDs. Passing a pinned `claude-*` ID through acpx's
+ * `--model` / `set model` fails validation against the advertised menu — and
+ * crashes specifically on session resume, where the adapter surfaces that menu.
+ * For pinned IDs we instead select the exact model via the Claude Agent SDK's
+ * `ANTHROPIC_MODEL` env var and omit the acpx model flag entirely.
+ */
+function usesClaudePinnedModelEnv(agent: string, model?: string): boolean {
+  return isClaudeAgent(agent) && CLAUDE_PINNED_MODEL_PATTERN.test(model?.trim() ?? "");
+}
+
+/**
+ * Environment overrides that pin a Claude model via `ANTHROPIC_MODEL`. Returns
+ * an empty object for non-Claude agents, advertised aliases (which acpx applies
+ * directly), or when `ANTHROPIC_MODEL` is already set by the operator.
+ */
+export function buildClaudePinnedModelEnv(options: {
+  agent: string;
+  model?: string;
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+}): Record<string, string> {
+  const model = options.model?.trim() ?? "";
+  if (!usesClaudePinnedModelEnv(options.agent, model)) {
+    return {};
+  }
+  const existingEnv = options.env ?? process.env;
+  if (existingEnv.ANTHROPIC_MODEL) {
+    return {};
+  }
+  return { ANTHROPIC_MODEL: model };
+}
+
 export interface AcpxModelSelection {
   model?: string;
   thoughtLevel?: string;
@@ -303,7 +344,10 @@ export function buildAcpxArgs(options: {
   }
   const model = options.model?.trim();
   const usesNamedSession = !options.isExecRoute && Boolean(options.sessionName);
-  if (model && !usesNamedSession) {
+  // Pinned Claude IDs are delivered via ANTHROPIC_MODEL (see
+  // buildClaudePinnedModelEnv); passing them as --model would fail acpx's
+  // advertised-model validation on resume.
+  if (model && !usesNamedSession && !usesClaudePinnedModelEnv(options.agent, model)) {
     args.push("--model", model);
   }
 
@@ -361,7 +405,10 @@ export function buildSessionSetupCommands(options: {
     thoughtLevel: options.thoughtLevel,
   });
   const commands: SessionSetupCommand[] = [];
-  if (modelSelection.model) {
+  // Pinned Claude IDs are delivered via ANTHROPIC_MODEL, not `set model`, which
+  // acpx validates against the adapter's advertised aliases (and rejects on
+  // resume). Advertised aliases still flow through `set model` normally.
+  if (modelSelection.model && !usesClaudePinnedModelEnv(options.agent, modelSelection.model)) {
     commands.push({
       label: "set model",
       args: [options.agent, "set", "model", modelSelection.model, "-s", options.sessionName],
@@ -745,6 +792,10 @@ export function runAcpx(options: AcpxRunOptions): AcpxRunResult {
   const modelSelection = resolveAcpxModelSelection({ agent, model, thoughtLevel });
   const selectedModel = modelSelection.model;
   const selectedThoughtLevel = modelSelection.thoughtLevel;
+  // Pin Claude models via ANTHROPIC_MODEL on every acpx spawn (session ensure,
+  // setup commands, and the prompt) so the exact model applies to new and
+  // resumed sessions alike, without tripping acpx's --model validation.
+  Object.assign(env, buildClaudePinnedModelEnv({ agent, model: selectedModel, env }));
   const needsTransientExecSession =
     preserveExecSession === true ||
     (isExecRoute && isCodexAgent(agent) && Boolean(selectedThoughtLevel));


### PR DESCRIPTION
## Problem

Claude ACPX runs fail on **session resume** with:

> Cannot apply --model "claude-opus-4-8": the ACP agent did not advertise that model. Available models: default, opus, haiku.

`@agentclientprotocol/claude-agent-acp` advertises models as **aliases** (`opus`/`sonnet`/`haiku`), not date/version-pinned IDs. acpx validates the requested model (passed as `--model` for exec routes, or `set model` for named sessions) against that advertised menu. Sepo's built-in Claude default is the pinned `claude-opus-4-8`, which isn't an advertised alias — so acpx rejects it. It surfaces on `session/resume` (where the resume result carries the menu), which means multi-turn runs (plan → implement → answer) die on the follow-up turn even though the first turn looked fine.

The pinned ID is a real, accepted API model — it just isn't an *advertised ACP model*, so acpx won't apply it.

## Fix

For pinned `claude-*` IDs, deliver the model through the Claude Agent SDK's **`ANTHROPIC_MODEL`** environment variable (set on every acpx spawn — session ensure, setup commands, and the prompt) and **omit acpx's `--model` / `set model`** flags. `ANTHROPIC_MODEL` selects the exact model directly, bypassing the advertised-alias menu, and applies identically to new and resumed sessions — so there's nothing for acpx to validate or reject.

- **Advertised aliases** (`opus`, etc.) are unchanged — they still flow through acpx's `--model` / `set model`, which the adapter accepts.
- **Non-Claude agents** (Codex) are unaffected.
- An **operator-set `ANTHROPIC_MODEL`** is respected (not overridden).

Verified end-to-end against `acpx@0.10.0` + `claude-agent-acp@0.36.1`: `ANTHROPIC_MODEL=claude-opus-4-8` with no `--model` runs cleanly on both `session/new` and `session/resume`; a deliberately invalid value errors with that value verbatim, confirming the env var drives model selection.

## Tests

- `buildClaudePinnedModelEnv` unit tests — pinned IDs (incl. the `[1m]` 1M-context suffix); aliases / Codex / preset-override all no-op.
- `buildAcpxArgs` and `buildSessionSetupCommands` omit the model flag/command for pinned `claude-*` IDs but keep it for advertised aliases.
- `runAcpx` integration test asserting `ANTHROPIC_MODEL` is set on the spawn and `--model` is not passed.

Full suite green locally: 628 runtime + 76 workflow + 5 docs + 15 shell, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
