### PR TITLE
Add post-job cleanup hook to self-hosted runner setup

### DIFF
--- a/.agent/tools/local-runner/README.md
+++ b/.agent/tools/local-runner/README.md
@@ -111,6 +111,20 @@ RUNNER_NAME_PREFIX=build-mac RUNNER_LABELS=self-hosted,macOS,ARM64,local \
   ./bootstrap.sh https://github.com/<OWNER> <REGISTRATION_TOKEN> 2
 ```
 
+## Post-job cleanup hook
+
+`hooks/post-job-cleanup.sh` runs after every job via the runner's
+`ACTIONS_RUNNER_HOOK_JOB_COMPLETED` mechanism. `setup-runners.sh` wires it into
+each runner's `.env`. On every job completion it:
+
+- trims `runner-N/_diag` to the last 30 files and drops anything older than 3 days;
+- removes `runner-N/_work/<repo>` checkouts not touched in the last 24 hours,
+  skipping the current job's repo so the checkout cache stays warm.
+
+It never fails the runner — errors are swallowed and progress is written to
+`runner-N/cleanup-hook.log`. Restart runners after editing the hook for the new
+behavior to take effect.
+
 ## Cleanup job
 
 `cleanup-runner.sh` writes to `cleanup.log` and:

--- a/.agent/tools/local-runner/README.md
+++ b/.agent/tools/local-runner/README.md
@@ -125,6 +125,21 @@ It never fails the runner — errors are swallowed and progress is written to
 `runner-N/cleanup-hook.log`. Restart runners after editing the hook for the new
 behavior to take effect.
 
+To wire the hook into already-configured runners on a host that predates this
+change, rerun `setup-runners.sh` (it appends the env var to each `runner-*/.env`
+if missing and leaves the runner config alone) and then restart:
+
+```bash
+./setup-runners.sh https://github.com/<ORG_OR_USER> <REGISTRATION_TOKEN>
+./stop-runners.sh && ./start-runners.sh
+```
+
+Or append the line manually to each `runner-N/.env` and restart:
+
+```
+ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/absolute/path/to/local-runner/hooks/post-job-cleanup.sh
+```
+
 ## Cleanup job
 
 `cleanup-runner.sh` writes to `cleanup.log` and:

--- a/.agent/tools/local-runner/README.md
+++ b/.agent/tools/local-runner/README.md
@@ -126,8 +126,9 @@ It never fails the runner — errors are swallowed and progress is written to
 behavior to take effect.
 
 To wire the hook into already-configured runners on a host that predates this
-change, rerun `setup-runners.sh` (it appends the env var to each `runner-*/.env`
-if missing and leaves the runner config alone) and then restart:
+change, rerun `setup-runners.sh` and restart. The script reconciles every
+existing `runner-*/.env` regardless of `num_runners`, so any non-empty token
+works (use a fresh registration token if you also want to add more runners):
 
 ```bash
 ./setup-runners.sh https://github.com/<ORG_OR_USER> <REGISTRATION_TOKEN>

--- a/.agent/tools/local-runner/hooks/post-job-cleanup.sh
+++ b/.agent/tools/local-runner/hooks/post-job-cleanup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Post-job cleanup hook for self-hosted runners.
+#
+# Wired in via ACTIONS_RUNNER_HOOK_JOB_COMPLETED in each runner's .env. The
+# runner invokes this script after every job, with GITHUB_* and RUNNER_*
+# env vars populated. It must never fail the runner — always exit 0.
+#
+# Behavior:
+#   * Trim runner-N/_diag to the last 30 files and drop anything > 3 days old.
+#   * Remove runner-N/_work/<repo> dirs not touched in the last 24h, skipping
+#     the current job's repo so checkout caching stays warm.
+
+set -u
+trap 'exit 0' ERR
+
+WORKSPACE="${RUNNER_WORKSPACE:-}"
+[ -n "$WORKSPACE" ] || exit 0
+
+WORK_DIR="$(dirname "$WORKSPACE")"
+RUNNER_ROOT="$(dirname "$WORK_DIR")"
+DIAG_DIR="$RUNNER_ROOT/_diag"
+LOG="$RUNNER_ROOT/cleanup-hook.log"
+
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+current_repo="${GITHUB_REPOSITORY##*/}"
+
+log "post-job: repo=${GITHUB_REPOSITORY:-?} workflow=${GITHUB_WORKFLOW:-?} run=${GITHUB_RUN_ID:-?}"
+
+if [ -d "$DIAG_DIR" ]; then
+  before=$(du -sk "$DIAG_DIR" 2>/dev/null | awk '{print $1}')
+  ls -1t "$DIAG_DIR" 2>/dev/null | awk 'NR>30' | while read -r f; do
+    rm -f "$DIAG_DIR/$f" 2>/dev/null || true
+  done
+  find "$DIAG_DIR" -type f -mtime +3 -delete 2>/dev/null || true
+  after=$(du -sk "$DIAG_DIR" 2>/dev/null | awk '{print $1}')
+  log "_diag trimmed: ${before:-?}K -> ${after:-?}K"
+fi
+
+if [ -d "$WORK_DIR" ]; then
+  for d in "$WORK_DIR"/*; do
+    [ -d "$d" ] || continue
+    name=$(basename "$d")
+    case "$name" in
+      _*|"$current_repo") continue ;;
+    esac
+    if [ -z "$(find "$d" -maxdepth 0 -mtime -1 -print 2>/dev/null)" ]; then
+      size=$(du -sk "$d" 2>/dev/null | awk '{print $1}')
+      rm -rf "$d" 2>/dev/null && log "pruned _work/$name (${size:-?}K)"
+    fi
+  done
+fi
+
+exit 0

--- a/.agent/tools/local-runner/hooks/post-job-cleanup.sh
+++ b/.agent/tools/local-runner/hooks/post-job-cleanup.sh
@@ -17,6 +17,7 @@ WORKSPACE="${RUNNER_WORKSPACE:-}"
 [ -n "$WORKSPACE" ] || exit 0
 
 WORK_DIR="$(dirname "$WORKSPACE")"
+[ "$(basename "$WORK_DIR")" = "_work" ] || exit 0
 RUNNER_ROOT="$(dirname "$WORK_DIR")"
 DIAG_DIR="$RUNNER_ROOT/_diag"
 LOG="$RUNNER_ROOT/cleanup-hook.log"
@@ -45,7 +46,10 @@ if [ -d "$WORK_DIR" ]; then
     case "$name" in
       _*|"$current_repo") continue ;;
     esac
-    if [ -z "$(find "$d" -maxdepth 0 -mtime -1 -print 2>/dev/null)" ]; then
+    # Check for any file (incl. nested) touched in the last 24h. -print -quit
+    # stops on first match so warm checkouts return immediately; cold trees pay
+    # the full scan but are about to be deleted.
+    if [ -z "$(find "$d" -type f -mtime -1 -print -quit 2>/dev/null)" ]; then
       size=$(du -sk "$d" 2>/dev/null | awk '{print $1}')
       rm -rf "$d" 2>/dev/null && log "pruned _work/$name (${size:-?}K)"
     fi

--- a/.agent/tools/local-runner/setup-runners.sh
+++ b/.agent/tools/local-runner/setup-runners.sh
@@ -162,6 +162,11 @@ for i in $(seq 1 "$NUM_RUNNERS"); do
       --replace
   )
 
+  HOOK_SCRIPT="$BASE_DIR/hooks/post-job-cleanup.sh"
+  if [ -x "$HOOK_SCRIPT" ] && ! grep -q ACTIONS_RUNNER_HOOK_JOB_COMPLETED "$RUNNER_DIR/.env" 2>/dev/null; then
+    echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=$HOOK_SCRIPT" >> "$RUNNER_DIR/.env"
+  fi
+
   echo "Runner $i configured as $RUNNER_NAME."
 done
 

--- a/.agent/tools/local-runner/setup-runners.sh
+++ b/.agent/tools/local-runner/setup-runners.sh
@@ -150,6 +150,14 @@ ensure_hook_env() {
   echo "Wired post-job cleanup hook into $runner_dir/.env (restart runner to apply)."
 }
 
+# Reconcile the hook into every existing runner, regardless of NUM_RUNNERS,
+# so multi-runner hosts get all runners updated on a plain rerun.
+for existing in "$BASE_DIR"/runner-*/; do
+  [ -d "$existing" ] || continue
+  [ -f "$existing/.runner" ] || continue
+  ensure_hook_env "${existing%/}"
+done
+
 for i in $(seq 1 "$NUM_RUNNERS"); do
   RUNNER_DIR="$BASE_DIR/runner-$i"
   RUNNER_NAME="$RUNNER_NAME_PREFIX-$i"

--- a/.agent/tools/local-runner/setup-runners.sh
+++ b/.agent/tools/local-runner/setup-runners.sh
@@ -139,12 +139,24 @@ fi
 echo "Verifying $RUNNER_ASSET..."
 verify_runner_tarball
 
+HOOK_SCRIPT="$BASE_DIR/hooks/post-job-cleanup.sh"
+
+ensure_hook_env() {
+  local runner_dir="$1"
+  [ -x "$HOOK_SCRIPT" ] || return 0
+  [ -f "$runner_dir/.env" ] || return 0
+  grep -q '^ACTIONS_RUNNER_HOOK_JOB_COMPLETED=' "$runner_dir/.env" && return 0
+  echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=$HOOK_SCRIPT" >> "$runner_dir/.env"
+  echo "Wired post-job cleanup hook into $runner_dir/.env (restart runner to apply)."
+}
+
 for i in $(seq 1 "$NUM_RUNNERS"); do
   RUNNER_DIR="$BASE_DIR/runner-$i"
   RUNNER_NAME="$RUNNER_NAME_PREFIX-$i"
 
   if [ -d "$RUNNER_DIR" ] && [ -f "$RUNNER_DIR/.runner" ]; then
     echo "Runner $i already configured at $RUNNER_DIR; skipping setup."
+    ensure_hook_env "$RUNNER_DIR"
     continue
   fi
 
@@ -162,10 +174,7 @@ for i in $(seq 1 "$NUM_RUNNERS"); do
       --replace
   )
 
-  HOOK_SCRIPT="$BASE_DIR/hooks/post-job-cleanup.sh"
-  if [ -x "$HOOK_SCRIPT" ] && ! grep -q ACTIONS_RUNNER_HOOK_JOB_COMPLETED "$RUNNER_DIR/.env" 2>/dev/null; then
-    echo "ACTIONS_RUNNER_HOOK_JOB_COMPLETED=$HOOK_SCRIPT" >> "$RUNNER_DIR/.env"
-  fi
+  ensure_hook_env "$RUNNER_DIR"
 
   echo "Runner $i configured as $RUNNER_NAME."
 done


### PR DESCRIPTION
## Summary
- Add `hooks/post-job-cleanup.sh`, wired via the runner's `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` mechanism: trims `_diag` to the last 30 files / 3 days, and removes `_work/<repo>` checkouts not touched in 24h (skipping the current job's repo so its cache stays warm).
- Update `setup-runners.sh` to append the env var to each new runner's `.env` at config time.
- Document the hook in `README.md`.

Closes #418

## Test plan
- [ ] On a host with existing runners: append `ACTIONS_RUNNER_HOOK_JOB_COMPLETED=<abs path>/hooks/post-job-cleanup.sh` to each `runner-*/.env`, restart runners, run a job, and confirm `runner-*/cleanup-hook.log` records the invocation.
- [ ] Confirm `_work/<repo>` for an unrelated repo gets pruned after its mtime crosses 24h.
- [ ] Confirm the current job's `_work/<repo>` is preserved across consecutive runs.
- [ ] Re-run `setup-runners.sh` for a fresh runner index and verify the new `.env` includes the hook line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)