### PR TITLE
Add Linux support to local-runner tooling

### DIFF
--- a/.agent/docs/setup/self-hosted-github-action-runner.md
+++ b/.agent/docs/setup/self-hosted-github-action-runner.md
@@ -13,7 +13,7 @@ Self-hosted runners are a good fit when you want:
 
 ## Local runner setup
 
-For the maintained setup scripts and step-by-step instructions, use [`.agent/tools/local-runner`](https://github.com/self-evolving/repo/blob/main/.agent/tools/local-runner/README.md). That folder contains the host requirement check, bootstrap, setup, start, stop, cleanup, and launchd template files for running local macOS self-hosted runners.
+For the maintained setup scripts and step-by-step instructions, use [`.agent/tools/local-runner`](https://github.com/self-evolving/repo/blob/main/.agent/tools/local-runner/README.md). That folder contains the host requirement check, bootstrap, setup, start, stop, cleanup, and cleanup scheduling files for running local macOS or Linux self-hosted runners. Scheduled cleanup uses launchd on macOS and cron on Linux.
 
 Keep this setup page focused on the decision to use self-hosted runners; keep machine-specific setup details in the local runner tool folder.
 

--- a/.agent/tools/local-runner/README.md
+++ b/.agent/tools/local-runner/README.md
@@ -204,7 +204,7 @@ Run cleanup manually (any OS):
 
 ```bash
 bash cleanup-runner.sh
-tail -f "$LOCAL_RUNNER_ROOT/cleanup.log"   # defaults to ./cleanup.log
+tail -f "${LOCAL_RUNNER_ROOT:-.}/cleanup.log"
 ```
 
 Check the scheduled job:

--- a/.agent/tools/local-runner/README.md
+++ b/.agent/tools/local-runner/README.md
@@ -1,29 +1,30 @@
 # Local GitHub Actions Runner
 
-Scripts for running one or more self-hosted GitHub Actions runners on a local macOS machine.
+Scripts for running one or more self-hosted GitHub Actions runners on a local macOS or Linux machine.
 
 The repository is intentionally generic: provide your own GitHub organization or repository URL and a short-lived registration token when you set up the runners.
 
 ## What this does
 
-- Downloads the GitHub Actions runner for your Mac (`osx-arm64` or `osx-x64`).
+- Downloads the GitHub Actions runner for your host: `osx-arm64` / `osx-x64` on macOS, or `linux-x64` / `linux-arm64` on Linux (auto-detected; override with `RUNNER_PLATFORM`).
 - Verifies the downloaded runner archive with the SHA-256 checksum from the GitHub runner release.
 - Creates `runner-1`, `runner-2`, ... directories so each runner has its own working directory.
 - Starts all configured runners and writes logs to `runner-N/runner.log`.
-- Optionally installs a macOS `launchd` cleanup job that removes old runner diagnostic logs every 6 hours.
+- Optionally installs a cleanup job that removes old runner diagnostic logs every 6 hours — via `launchd` on macOS or `cron` on Linux.
 
 ## Requirements
 
 `bootstrap.sh` and `setup-runners.sh` run `check-requirements.sh` before registering runners. For the default agent workflows, the runner host needs:
 
-- macOS with Bash, `git`, `gh`, `jq`, `curl`, `tar`, and `shasum`.
+- macOS or Linux with Bash, `git`, `gh`, `jq`, `curl`, `tar`, and a SHA-256 tool (`sha256sum` on Linux, `shasum` on macOS — either is accepted).
 - Node.js 22.x and npm. This matches the default `node_version` in `.github/actions/setup-agent-runtime` for self-hosted runners.
+- On Linux, the ICU library (`libicu`) that the .NET-based runner depends on. Most desktop/server distros ship it; minimal images may need `sudo apt-get install -y libicu-dev` (Debian/Ubuntu) or `sudo dnf install -y libicu` (RHEL/Rocky/Fedora). `check-requirements.sh` warns if it is missing.
 - Admin access to the target GitHub organization or repository so you can create a self-hosted runner registration token.
 - Docker is optional. Docker cleanup is disabled unless you explicitly opt in.
 
 You do **not** need to preinstall `acpx`: each workflow runs `npm ci` in `.agent/`, and `acpx` is a package dependency exposed through `.agent/node_modules/.bin`.
 
-You also do **not** need to preinstall `codex` or `claude` for normal secret-backed runs. The shared `setup-agent-runtime` action installs the selected provider CLI when it is missing. If you want to rely on local provider authentication instead of repository secrets, authenticate the provider CLI as the same macOS user that runs the GitHub runner service.
+You also do **not** need to preinstall `codex` or `claude` for normal secret-backed runs. The shared `setup-agent-runtime` action installs the selected provider CLI when it is missing. If you want to rely on local provider authentication instead of repository secrets, authenticate the provider CLI as the same OS user that runs the GitHub runner.
 
 ## Security note
 
@@ -49,7 +50,7 @@ To create multiple local runners:
 ./bootstrap.sh https://github.com/<ORG_OR_USER> <REGISTRATION_TOKEN> 3
 ```
 
-`bootstrap.sh` configures the runner(s), installs the cleanup schedule on macOS, and then starts the runners. Press `Ctrl+C` to stop them.
+`bootstrap.sh` configures the runner(s), installs the cleanup schedule (`launchd` on macOS, `cron` on Linux), and then starts the runners. Press `Ctrl+C` to stop them.
 
 > Registration tokens expire quickly. If setup fails with an authorization error, create a fresh token and run the command again. Do not commit tokens to the repository.
 
@@ -98,10 +99,11 @@ You can customize setup with environment variables:
 | `RUNNER_VERSION` | `2.332.0` | GitHub Actions runner version to download. |
 | `RUNNER_SHA256` | release checksum | Optional explicit SHA-256 checksum for the selected runner archive; useful if release checksum lookup is rate-limited. |
 | `GITHUB_TOKEN` | none | Optional token used only for runner release checksum lookup to avoid anonymous GitHub API rate limits. |
-| `RUNNER_PLATFORM` | auto-detected | Runner package platform, usually `osx-arm64` or `osx-x64`. |
-| `RUNNER_LABELS` | `self-hosted,macOS,ARM64` or `self-hosted,macOS,X64` | Labels passed to GitHub during runner registration. |
+| `RUNNER_PLATFORM` | auto-detected | Runner package platform: `osx-arm64` / `osx-x64` on macOS, `linux-x64` / `linux-arm64` on Linux. |
+| `RUNNER_LABELS` | `self-hosted,<macOS\|Linux>,<ARM64\|X64>` | Labels passed to GitHub during runner registration (OS and arch auto-detected). |
 | `RUNNER_NAME_PREFIX` | `<hostname>-runner` | Prefix for runner names. Runner numbers are appended. |
-| `RUNNER_TOOL_CACHE` | `./shared-tool-cache` | Shared tool cache used when runners are started. |
+| `LOCAL_RUNNER_ROOT` | this checkout | Directory that holds the runner working dirs (`runner-N`, downloaded runner cache, `_work`, tool cache, logs). Point it at a roomier filesystem when the checkout lives on a size- or inode-constrained one (see "Hosting the runner off a constrained filesystem"). |
+| `RUNNER_TOOL_CACHE` | `$LOCAL_RUNNER_ROOT/shared-tool-cache` | Shared tool cache used when runners are started. |
 | `LOCAL_RUNNER_DOCKER_PRUNE` | `0` | Set to `1` before running `bootstrap.sh` or `cleanup-runner.sh` to allow `docker system prune -f`. |
 
 Example:
@@ -110,6 +112,44 @@ Example:
 RUNNER_NAME_PREFIX=build-mac RUNNER_LABELS=self-hosted,macOS,ARM64,local \
   ./bootstrap.sh https://github.com/<OWNER> <REGISTRATION_TOKEN> 2
 ```
+
+## Hosting the runner off a constrained filesystem
+
+By default the runner directories live inside this checkout. On many servers that
+is fine, but on HPC login nodes and other managed hosts the home filesystem often
+has a per-user **quota** — not just on bytes, but on **inode count** (number of
+files). A GitHub Actions runner is inode-heavy: the base install is ~20k+ files,
+each agent job's `npm ci` adds tens of thousands more under `_work`, and the
+runner's periodic self-update briefly writes a *second* full copy of itself. Any
+of these can blow an inode quota, and the failure surfaces as a confusing
+`Disk quota exceeded` error mid-job (or during self-update).
+
+Set `LOCAL_RUNNER_ROOT` to a filesystem with room (scratch, project, or pool
+storage) so all runner state lands there instead of the quota'd home:
+
+```bash
+export LOCAL_RUNNER_ROOT=/path/to/roomy/storage/github-runners
+./bootstrap.sh https://github.com/<ORG_OR_USER>/<REPO> <REGISTRATION_TOKEN>
+```
+
+`setup-runners.sh`, `start-runners.sh`, `stop-runners.sh`, and `cleanup-runner.sh`
+all honor `LOCAL_RUNNER_ROOT`, so export it (or prefix each command with it)
+consistently. Only the scripts and the post-job hook stay in the checkout; all
+runner *data* lives under `LOCAL_RUNNER_ROOT`.
+
+To move an already-configured runner without re-registering it, stop it, move the
+directories across (registration travels with the `runner-N` directory), then
+restart with the variable set:
+
+```bash
+./stop-runners.sh
+mv runner-* actions-runner shared-tool-cache /path/to/roomy/storage/github-runners/
+export LOCAL_RUNNER_ROOT=/path/to/roomy/storage/github-runners
+./start-runners.sh
+```
+
+Check inode usage with `df -i <path>` (and, where available, `quota -s`) before
+and after.
 
 ## Post-job cleanup hook
 
@@ -155,26 +195,34 @@ LOCAL_RUNNER_DOCKER_PRUNE=1 bash cleanup-runner.sh
 
 To opt in for the scheduled cleanup job, set `LOCAL_RUNNER_DOCKER_PRUNE=1` when you run `bootstrap.sh`.
 
-`bootstrap.sh` renders `com.local-runner.cleanup.plist.template` with this repository's local absolute path, writes it to `~/Library/LaunchAgents/com.local-runner.cleanup.plist`, and loads it with `launchctl`.
+`bootstrap.sh` installs the schedule differently per OS:
+
+- **macOS (`launchd`):** renders `com.local-runner.cleanup.plist.template` with this repository's local absolute path, writes it to `~/Library/LaunchAgents/com.local-runner.cleanup.plist`, and loads it with `launchctl`.
+- **Linux (`cron`):** adds a user crontab entry that runs `cleanup-runner.sh` every 6 hours (`0 */6 * * *`). A systemd `--user` timer is intentionally not used because it needs a user D-Bus session and lingering, which are often unavailable on shared/HPC hosts. Cleanup only runs while the cron daemon (`crond`) is active, and some managed hosts disable per-user `crontab` entirely — `bootstrap.sh` reports this and falls back to manual cleanup rather than failing.
+
+Run cleanup manually (any OS):
+
+```bash
+bash cleanup-runner.sh
+tail -f "$LOCAL_RUNNER_ROOT/cleanup.log"   # defaults to ./cleanup.log
+```
 
 Check the scheduled job:
 
 ```bash
-launchctl list | grep local-runner.cleanup
-```
-
-Run cleanup manually:
-
-```bash
-bash cleanup-runner.sh
-tail -f cleanup.log
+launchctl list | grep local-runner.cleanup     # macOS
+crontab -l | grep local-runner-cleanup          # Linux
 ```
 
 Disable the scheduled job:
 
 ```bash
+# macOS
 launchctl unload ~/Library/LaunchAgents/com.local-runner.cleanup.plist
 rm ~/Library/LaunchAgents/com.local-runner.cleanup.plist
+
+# Linux (remove the local-runner-cleanup line)
+crontab -l | grep -v local-runner-cleanup | crontab -
 ```
 
 ## Resetting runners
@@ -188,9 +236,13 @@ To recreate a runner from scratch:
 
 ## Files created locally
 
-The scripts create local runtime files that are ignored by Git:
+The scripts create runtime files under `LOCAL_RUNNER_ROOT` (the checkout by
+default, where they are ignored by Git):
 
 - `actions-runner/` — downloaded runner tarballs.
 - `runner-*/` — configured runner directories and workspaces.
 - `shared-tool-cache/` — reusable tool cache for started runners.
 - `*.log` — runner and cleanup logs.
+
+When `LOCAL_RUNNER_ROOT` points outside the checkout, these live there instead
+and Git never sees them.

--- a/.agent/tools/local-runner/bootstrap.sh
+++ b/.agent/tools/local-runner/bootstrap.sh
@@ -91,11 +91,13 @@ if [ "$(uname -s)" = "Darwin" ]; then
     rm -f "$PLIST_PATH"
   fi
 
-  # Render the template with this checkout's absolute path. Escape first for XML,
-  # then for sed replacement syntax so XML-sensitive path characters remain valid.
+  # Render path placeholders after escaping first for XML, then for sed
+  # replacement syntax so XML-sensitive path characters remain valid.
   ESCAPED_BASE_DIR=$(sed_replacement_escape "$(xml_escape "$BASE_DIR")")
+  ESCAPED_RUNNER_ROOT=$(sed_replacement_escape "$(xml_escape "$RUNNER_ROOT")")
   sed \
     -e "s|__PROJECT_DIR__|$ESCAPED_BASE_DIR|g" \
+    -e "s|__LOCAL_RUNNER_ROOT__|$ESCAPED_RUNNER_ROOT|g" \
     -e "s|__LOCAL_RUNNER_DOCKER_PRUNE__|$LOCAL_RUNNER_DOCKER_PRUNE|g" \
     "$PLIST_TEMPLATE" > "$PLIST_PATH"
 

--- a/.agent/tools/local-runner/bootstrap.sh
+++ b/.agent/tools/local-runner/bootstrap.sh
@@ -14,6 +14,10 @@ GITHUB_URL=${1:-${GITHUB_URL:-}}
 TOKEN=${2:-${RUNNER_TOKEN:-}}
 NUM_RUNNERS=${3:-${NUM_RUNNERS:-1}}
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Runner working directories may live outside this checkout (see LOCAL_RUNNER_ROOT
+# in setup-runners.sh). setup/start/stop read it from the environment; we only
+# need it here to point scheduled cleanup at the same location.
+RUNNER_ROOT="${LOCAL_RUNNER_ROOT:-$BASE_DIR}"
 PLIST_TEMPLATE="$BASE_DIR/com.local-runner.cleanup.plist.template"
 PLIST_PATH="$HOME/Library/LaunchAgents/com.local-runner.cleanup.plist"
 LOCAL_RUNNER_DOCKER_PRUNE=${LOCAL_RUNNER_DOCKER_PRUNE:-0}
@@ -97,8 +101,34 @@ if [ "$(uname -s)" = "Darwin" ]; then
 
   launchctl load "$PLIST_PATH"
   echo "Cleanup scheduled: $PLIST_PATH"
+elif [ "$(uname -s)" = "Linux" ]; then
+  # Linux has no launchd. Prefer cron, which does not require a user D-Bus
+  # session or lingering the way a systemd --user timer would.
+  if command -v crontab >/dev/null 2>&1; then
+    CRON_MARKER="# local-runner-cleanup ($BASE_DIR)"
+    # The trailing marker is a shell comment when cron runs the line, so it is
+    # ignored at execution time but lets us find and replace our own entry.
+    CRON_LINE="0 */6 * * * LOCAL_RUNNER_ROOT=\"$RUNNER_ROOT\" LOCAL_RUNNER_DOCKER_PRUNE=$LOCAL_RUNNER_DOCKER_PRUNE /bin/bash \"$BASE_DIR/cleanup-runner.sh\" $CRON_MARKER"
+
+    # `crontab -l` exits non-zero when no crontab exists; capture without tripping set -e.
+    if EXISTING_CRON="$(crontab -l 2>/dev/null)"; then :; else EXISTING_CRON=""; fi
+
+    # Keep every existing line except a prior entry for this checkout, then
+    # append the refreshed schedule. `|| true` swallows grep's no-match exit.
+    FILTERED_CRON="$(printf '%s\n' "$EXISTING_CRON" | grep -vF "$CRON_MARKER" | sed '/^[[:space:]]*$/d' || true)"
+    NEW_CRON="${FILTERED_CRON:+$FILTERED_CRON$'\n'}$CRON_LINE"
+
+    if printf '%s\n' "$NEW_CRON" | crontab -; then
+      echo "Cleanup scheduled via cron (every 6 hours): $BASE_DIR/cleanup-runner.sh"
+      echo "Note: cleanup only runs while the cron daemon (crond) is active on this host."
+    else
+      echo "Could not install cron job. Run cleanup-runner.sh manually or add it to your crontab."
+    fi
+  else
+    echo "crontab not found. Skipping scheduled cleanup; run cleanup-runner.sh manually if needed."
+  fi
 else
-  echo "Skipping launchd setup because this is not macOS. Run cleanup-runner.sh manually if needed."
+  echo "Skipping scheduled cleanup setup on $(uname -s). Run cleanup-runner.sh manually if needed."
 fi
 
 echo ""

--- a/.agent/tools/local-runner/check-requirements.sh
+++ b/.agent/tools/local-runner/check-requirements.sh
@@ -1,25 +1,36 @@
 #!/usr/bin/env bash
-# Verify that this macOS host has the tools the agent workflows expect on a
-# self-hosted runner. Provider CLIs are handled by setup-agent-runtime, so this
-# script focuses on host tools that must exist before a workflow starts.
+# Verify that this macOS or Linux host has the tools the agent workflows expect
+# on a self-hosted runner. Provider CLIs are handled by setup-agent-runtime, so
+# this script focuses on host tools that must exist before a workflow starts.
 
 set -euo pipefail
 
 REQUIRED_NODE_MAJOR=${LOCAL_RUNNER_NODE_VERSION:-22}
 
 missing=()
-for cmd in git gh jq curl tar shasum node npm; do
+for cmd in git gh jq curl tar node npm; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     missing+=("$cmd")
   fi
 done
 
+# The runner download is checksum-verified with sha256sum (Linux/coreutils) or
+# shasum (macOS). Require at least one of them.
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+  missing+=("sha256sum-or-shasum")
+fi
+
 if [ "${#missing[@]}" -ne 0 ]; then
   echo "Missing required runner tools: ${missing[*]}" >&2
   echo "" >&2
   echo "Install the missing tools before registering local agent runners." >&2
-  echo "On macOS with Homebrew, this usually means:" >&2
+  echo "On macOS with Homebrew:" >&2
   echo "  brew install git gh jq node@22" >&2
+  echo "On Debian/Ubuntu:" >&2
+  echo "  sudo apt-get install -y git jq curl tar coreutils   # plus gh + Node.js 22.x" >&2
+  echo "On RHEL/Rocky/Fedora:" >&2
+  echo "  sudo dnf install -y git jq curl tar coreutils        # plus gh + Node.js 22.x" >&2
+  echo "  (gh: https://github.com/cli/cli#installation, Node.js: https://github.com/nodesource/distributions)" >&2
   echo "" >&2
   echo "The agent workflows install acpx and provider CLIs as needed, but they" >&2
   echo "require these base tools to be available before the workflow starts." >&2
@@ -46,11 +57,25 @@ if [ -n "$npm_global_prefix" ] && [ ! -w "$npm_global_prefix" ] && [ ! -w "$(dir
   echo "If a workflow needs to install Codex, preinstall it or use a user-writable Node/npm installation." >&2
 fi
 
+# The GitHub Actions runner is a .NET application that needs ICU (libicu) on
+# Linux. Full desktop/server distros ship it, but minimal images may not. Warn
+# (do not fail) so the operator can install it or run the runner's bundled
+# bin/installdependencies.sh before starting runners.
+if [ "$(uname -s)" = "Linux" ] && command -v ldconfig >/dev/null 2>&1; then
+  if ! ldconfig -p 2>/dev/null | grep -qi 'libicu'; then
+    echo "Warning: libicu was not found in the dynamic linker cache. The GitHub Actions" >&2
+    echo "runner needs it. Install it before starting runners, for example:" >&2
+    echo "  Debian/Ubuntu: sudo apt-get install -y libicu-dev" >&2
+    echo "  RHEL/Rocky:    sudo dnf install -y libicu" >&2
+    echo "or run ./bin/installdependencies.sh from a configured runner-* directory." >&2
+  fi
+fi
+
 echo ""
 echo "Agent runtime tools:"
 echo "- acpx is installed per workflow by npm ci from .agent/package.json; no host install is required."
 echo "- codex and claude are installed on demand by .github/actions/setup-agent-runtime when the selected provider needs them."
-echo "- if you rely on local provider auth instead of repository secrets, authenticate the provider CLI as this macOS user before running jobs."
+echo "- if you rely on local provider auth instead of repository secrets, authenticate the provider CLI as the same user that runs the runner before running jobs."
 
 if command -v codex >/dev/null 2>&1; then
   echo "Optional Codex CLI: found ($(command -v codex))"

--- a/.agent/tools/local-runner/cleanup-runner.sh
+++ b/.agent/tools/local-runner/cleanup-runner.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Cleanup script for local self-hosted GitHub Actions runners.
-# Intended to run every 6 hours via launchd on macOS.
+# Intended to run every 6 hours via launchd on macOS or cron on Linux.
 
 set -euo pipefail
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
-LOG_FILE="$BASE_DIR/cleanup.log"
+# Runner working directories may live outside this checkout (see LOCAL_RUNNER_ROOT).
+RUNNER_ROOT="${LOCAL_RUNNER_ROOT:-$BASE_DIR}"
+LOG_FILE="$RUNNER_ROOT/cleanup.log"
 exec >> "$LOG_FILE" 2>&1
 
 echo "=== Cleanup started: $(date) ==="
@@ -23,7 +25,7 @@ fi
 
 # Remove old runner diagnostic logs (older than 7 days) from all configured runners.
 echo "Cleaning runner diagnostic logs older than 7 days..."
-find "$BASE_DIR" -path "$BASE_DIR/runner-*/_diag/*.log" -type f -mtime +7 -delete 2>/dev/null || true
+find "$RUNNER_ROOT" -path "$RUNNER_ROOT/runner-*/_diag/*.log" -type f -mtime +7 -delete 2>/dev/null || true
 
 echo "Disk: $(df -h / | awk 'NR==2{print $4 " free"}')"
 echo "=== Cleanup finished: $(date) ==="

--- a/.agent/tools/local-runner/com.local-runner.cleanup.plist.template
+++ b/.agent/tools/local-runner/com.local-runner.cleanup.plist.template
@@ -16,6 +16,8 @@
 
     <key>EnvironmentVariables</key>
     <dict>
+        <key>LOCAL_RUNNER_ROOT</key>
+        <string>__LOCAL_RUNNER_ROOT__</string>
         <key>LOCAL_RUNNER_DOCKER_PRUNE</key>
         <string>__LOCAL_RUNNER_DOCKER_PRUNE__</string>
     </dict>

--- a/.agent/tools/local-runner/setup-runners.sh
+++ b/.agent/tools/local-runner/setup-runners.sh
@@ -14,6 +14,12 @@ GITHUB_URL=${1:-${GITHUB_URL:-}}
 TOKEN=${2:-${RUNNER_TOKEN:-}}
 NUM_RUNNERS=${3:-${NUM_RUNNERS:-1}}
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Where runner working directories (runner-N, actions-runner cache, _work, tool
+# cache, logs) live. Defaults to this checkout. On hosts where the checkout sits
+# on a size- or inode-constrained filesystem (e.g. an HPC home directory with a
+# per-user file-count quota), point LOCAL_RUNNER_ROOT at a roomier location; all
+# of setup/start/stop/cleanup honor it consistently.
+RUNNER_ROOT="${LOCAL_RUNNER_ROOT:-$BASE_DIR}"
 RUNNER_VERSION=${RUNNER_VERSION:-2.332.0}
 
 usage() {
@@ -34,6 +40,12 @@ detect_runner_platform() {
     Darwin-x86_64)
       echo "osx-x64"
       ;;
+    Linux-x86_64)
+      echo "linux-x64"
+      ;;
+    Linux-aarch64 | Linux-arm64)
+      echo "linux-arm64"
+      ;;
     *)
       echo "Unsupported platform: $(uname -s) $(uname -m). Set RUNNER_PLATFORM explicitly if a runner package exists for this machine." >&2
       exit 1
@@ -47,6 +59,27 @@ runner_arch_label() {
     *x64*) echo "X64" ;;
     *) echo "$1" ;;
   esac
+}
+
+runner_os_label() {
+  case "$1" in
+    osx-*) echo "macOS" ;;
+    linux-*) echo "Linux" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# Compute a SHA-256 digest with whichever tool the host provides. macOS ships
+# `shasum`; most Linux distros ship coreutils `sha256sum` and may omit `shasum`.
+compute_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "Neither sha256sum nor shasum is available to verify the runner download." >&2
+    exit 1
+  fi
 }
 
 escape_basic_regex() {
@@ -87,7 +120,7 @@ verify_runner_tarball() {
     exit 1
   fi
 
-  actual_sha=$(shasum -a 256 "$RUNNER_TAR" | awk '{print $1}')
+  actual_sha=$(compute_sha256 "$RUNNER_TAR")
 
   if [ "$actual_sha" != "$expected_sha" ]; then
     echo "Checksum mismatch for $RUNNER_TAR" >&2
@@ -120,11 +153,11 @@ if [ "${LOCAL_RUNNER_REQUIREMENTS_CHECKED:-0}" != "1" ]; then
 fi
 
 RUNNER_PLATFORM=${RUNNER_PLATFORM:-$(detect_runner_platform)}
-DEFAULT_LABELS="self-hosted,macOS,$(runner_arch_label "$RUNNER_PLATFORM")"
+DEFAULT_LABELS="self-hosted,$(runner_os_label "$RUNNER_PLATFORM"),$(runner_arch_label "$RUNNER_PLATFORM")"
 RUNNER_LABELS=${RUNNER_LABELS:-$DEFAULT_LABELS}
 DEFAULT_RUNNER_NAME_PREFIX="$(hostname -s 2>/dev/null || hostname)-runner"
 RUNNER_NAME_PREFIX=${RUNNER_NAME_PREFIX:-$DEFAULT_RUNNER_NAME_PREFIX}
-RUNNER_CACHE_DIR="$BASE_DIR/actions-runner"
+RUNNER_CACHE_DIR="$RUNNER_ROOT/actions-runner"
 RUNNER_ASSET="actions-runner-${RUNNER_PLATFORM}-${RUNNER_VERSION}.tar.gz"
 RUNNER_TAR="$RUNNER_CACHE_DIR/$RUNNER_ASSET"
 RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/$RUNNER_ASSET"
@@ -152,14 +185,14 @@ ensure_hook_env() {
 
 # Reconcile the hook into every existing runner, regardless of NUM_RUNNERS,
 # so multi-runner hosts get all runners updated on a plain rerun.
-for existing in "$BASE_DIR"/runner-*/; do
+for existing in "$RUNNER_ROOT"/runner-*/; do
   [ -d "$existing" ] || continue
   [ -f "$existing/.runner" ] || continue
   ensure_hook_env "${existing%/}"
 done
 
 for i in $(seq 1 "$NUM_RUNNERS"); do
-  RUNNER_DIR="$BASE_DIR/runner-$i"
+  RUNNER_DIR="$RUNNER_ROOT/runner-$i"
   RUNNER_NAME="$RUNNER_NAME_PREFIX-$i"
 
   if [ -d "$RUNNER_DIR" ] && [ -f "$RUNNER_DIR/.runner" ]; then

--- a/.agent/tools/local-runner/start-runners.sh
+++ b/.agent/tools/local-runner/start-runners.sh
@@ -5,6 +5,9 @@
 set -euo pipefail
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Runner working directories may live outside this checkout (see LOCAL_RUNNER_ROOT
+# in setup-runners.sh), e.g. on a roomier filesystem than a quota'd HPC home.
+RUNNER_ROOT="${LOCAL_RUNNER_ROOT:-$BASE_DIR}"
 PIDS=()
 
 cleanup() {
@@ -20,7 +23,7 @@ cleanup() {
 trap cleanup SIGINT SIGTERM
 
 # Share tool cache (Node, Python, etc.) across all runners to avoid re-downloading.
-export RUNNER_TOOL_CACHE="${RUNNER_TOOL_CACHE:-$BASE_DIR/shared-tool-cache}"
+export RUNNER_TOOL_CACHE="${RUNNER_TOOL_CACHE:-$RUNNER_ROOT/shared-tool-cache}"
 mkdir -p "$RUNNER_TOOL_CACHE"
 
 # Ask the GitHub runner wrapper to trap signals and forward them to the
@@ -30,7 +33,7 @@ export RUNNER_MANUALLY_TRAP_SIG=1
 
 echo "Starting runners..."
 
-for dir in "$BASE_DIR"/runner-*/; do
+for dir in "$RUNNER_ROOT"/runner-*/; do
   [ -d "$dir" ] || continue
   [ -f "$dir/.runner" ] || { echo "Skipping unconfigured dir: $dir"; continue; }
 
@@ -48,6 +51,6 @@ fi
 
 echo ""
 echo "${#PIDS[@]} runner(s) started. Press Ctrl+C to stop all."
-echo "To view logs: tail -f $BASE_DIR/runner-*/runner.log"
+echo "To view logs: tail -f $RUNNER_ROOT/runner-*/runner.log"
 
 wait

--- a/.agent/tools/local-runner/stop-runners.sh
+++ b/.agent/tools/local-runner/stop-runners.sh
@@ -4,9 +4,11 @@
 set -euo pipefail
 
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Runner working directories may live outside this checkout (see LOCAL_RUNNER_ROOT).
+RUNNER_ROOT="${LOCAL_RUNNER_ROOT:-$BASE_DIR}"
 FOUND=0
 
-for dir in "$BASE_DIR"/runner-*/; do
+for dir in "$RUNNER_ROOT"/runner-*/; do
   [ -d "$dir" ] || continue
   FOUND=1
   runner_path="${dir%/}"


### PR DESCRIPTION
The local-runner scripts only targeted macOS (osx-* runner packages, launchd cleanup, shasum). Make them work on Linux hosts too:

- setup-runners.sh: detect linux-x64/linux-arm64, derive OS/arch labels (self-hosted,Linux,X64 instead of hardcoded macOS), and verify the download with sha256sum or shasum.
- check-requirements.sh: accept either SHA-256 tool, add Debian/Ubuntu and RHEL/Rocky install hints, and warn when libicu (needed by the .NET-based runner) is missing.
- bootstrap.sh: install the 6-hourly cleanup via cron on Linux (launchd is macOS-only); degrade gracefully when per-user crontab is unavailable.
- Add LOCAL_RUNNER_ROOT so runner working dirs can live off a size- or inode-constrained filesystem (e.g. an HPC home with a per-user file quota); honored by setup/start/stop/cleanup.
- README: document Linux setup, cron cleanup, and LOCAL_RUNNER_ROOT.