### PR TITLE
Keep automated review fixes within PR scope

### DIFF
--- a/.github/prompts/agent-fix-pr.md
+++ b/.github/prompts/agent-fix-pr.md
@@ -19,21 +19,20 @@ Instructions:
    - For issue_comment: `gh api repos/${REPO_SLUG}/issues/comments/${REQUEST_COMMENT_ID}`
    - For pull_request_review_comment: `gh api repos/${REPO_SLUG}/pulls/comments/${REQUEST_COMMENT_ID}`
    - For pull_request_review: `gh api repos/${REPO_SLUG}/pulls/${TARGET_NUMBER}/reviews/${REQUEST_COMMENT_ID}`
-4. Before editing, identify the latest actionable request you are addressing.
-   Use this priority order and do not revive older feedback that appears fixed
-   or superseded:
+4. Before editing, identify the latest actionable request. When
+   `${ORCHESTRATOR_CONTEXT}` is non-empty, it is the exclusive authorized task;
+   implement that selected task and do not add findings from elsewhere. The
+   context may contain labeled synthesis items or prose from another supported
+   handoff. Otherwise use this priority order without reviving superseded feedback:
    1. the exact triggering comment or review, when an ID is present;
-   2. non-empty `${ORCHESTRATOR_CONTEXT}` from the orchestrator; treat it as
-      the selected fix-pr task and constraints, not just background context;
-   3. the latest review synthesis and its action items;
-   4. recent human maintainer comments;
-   5. older reviews/comments only when still applicable to the current diff.
-5. Treat INFO-level notes, explicitly optional suggestions, already-fixed
-   findings, and human-judgment nits as non-actionable unless the exact
-   trigger or handoff context explicitly asks you to handle them.
-6. Address the selected PR feedback with the smallest complete change. If no
-   actionable branch change remains, leave the working tree unchanged and say
-   so clearly in the JSON summary.
+   2. the latest review synthesis and its action items;
+   3. recent human maintainer comments;
+   4. older reviews/comments only when still applicable to the current diff.
+5. Treat `FOLLOW_UP`, `HUMAN_DECISION`, optional suggestions, and already-fixed
+   findings as non-actionable unless directly requested by a human trigger.
+6. Make the smallest complete change within the PR's stated scope. If the task
+   requires scope expansion or no authorized change remains, leave the tree
+   unchanged and say so clearly in the JSON summary.
 7. Run lightweight, directly relevant checks when they are clearly applicable.
 8. If a line-specific clarification is useful, you may post an inline PR comment
    with `gh`, but do not post a top-level summary comment.

--- a/.github/prompts/agent-orchestrator.md
+++ b/.github/prompts/agent-orchestrator.md
@@ -85,10 +85,12 @@ rubrics. Then return exactly one JSON object and nothing else:
 ```
 
 Rules:
-- If the latest review synthesis includes a `Recommended Next Step`, treat it
-  as the primary automation signal: hand off on `FIX_PR`, hand off to
-  `agent-self-approve` on `HUMAN_DECISION` when self-approval is enabled, and
-  stop on `HUMAN_DECISION` or `NO_AUTOMATED_ACTION` otherwise.
+- Treat the latest review synthesis `Recommended Next Step` as the primary
+  automation signal. `FIX_PR` may hand off only labeled `FIX_IN_PR` action
+  items. `FOLLOW_UP` findings never trigger `fix-pr`. Preserve the existing
+  `HUMAN_DECISION` self-approval or human-stop behavior.
+- Before any automated `fix-pr` handoff, stop for human review if the current
+  chain already completed one fix-pr pass.
 - Use `handoff` only when one more automatic action is clearly warranted.
 - For issue-level `orchestrate`, prefer `handoff` with `next_action:
   "implement"` when the requested work fits in the current issue. Use
@@ -113,9 +115,9 @@ Rules:
 - Use `stop` when the task appears complete, the result is unsupported, or the
   next step should be left to a human.
 - Stop instead of handing off when the remaining items are metadata-only
-  (for example PR title/body/labels/comments), optional suggestions, INFO-level
-  notes, style or naming preferences, already-fixed findings, or other
-  human-judgment nits.
+  (for example PR title/body/labels/comments), optional suggestions, `INFO` /
+  `FOLLOW_UP` findings, style or naming preferences, already-fixed findings, or
+  other human-judgment nits.
 - Use `blocked` when required context is missing or the chain cannot proceed
   safely. Include `user_message` and/or `clarification_request` with text that
   can be posted directly as the visible clarification comment.
@@ -126,10 +128,9 @@ Rules:
   a question before continuing, choose `blocked` with a clarification message.
 - Omit `next_action` unless `decision` is `handoff`.
 - Include `handoff_context` for `handoff` decisions when useful. For `fix-pr`,
-  it is required: preserve any non-empty source handoff context, or make the
-  task concrete by summarizing the exact review findings to address,
-  constraints to preserve, and unrelated work to avoid.
-- When `agent-self-approve` returns `REQUEST_CHANGES`, hand off to `fix-pr`
-  and preserve the source handoff context as the fix-pr task.
+  it is required and must contain only selected `FIX_IN_PR` items plus the scope
+  constraints to preserve. Do not include follow-up or undecided work.
+- When `agent-self-approve` returns `REQUEST_CHANGES`, apply the same one-pass
+  and labeled-task requirements before handing off to `fix-pr`; otherwise stop.
 - When `agent-self-approve` returns `APPROVED` and self-merge is enabled, hand
   off to `agent-self-merge`.

--- a/.github/prompts/review-synthesize.md
+++ b/.github/prompts/review-synthesize.md
@@ -12,6 +12,11 @@ verdict, verify that each unresolved issue is supported by the current
 findings from older agent conversations or prior PR discussion unless they are
 still grounded in the current review artifacts or current diff.
 
+Reassess each finding against the PR's intended scope. Use `FIX_IN_PR` or
+`HUMAN_DECISION` only with `BLOCKING` or `WARNING`; use `FOLLOW_UP` only with
+`INFO`. Only `FIX_IN_PR` authorizes branch changes. Prefer a bounded fail-closed
+fix over scope-expanding hardening.
+
 Use `gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json title,body,comments,reviews`
 to inspect the current PR conversation before synthesizing.
 Use `gh api --paginate repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/comments`
@@ -72,7 +77,7 @@ inline comments sparingly:
 
 Produce a unified review synthesis:
 1. Deduplicate overlapping findings and note meaningful reviewer disagreements
-2. Prioritize BLOCKING > WARNING > INFO and use those exact severity labels
+2. Prioritize BLOCKING > WARNING > INFO, and preserve each disposition
 3. Make the top of the synthesis easy to scan before readers open details
 4. Add a "Progress" section describing what is already acknowledged or fixed
 5. Add a "Recommended Next Step" section that labels the ideal next step for
@@ -89,9 +94,12 @@ Format as clean GitHub-flavored markdown with this structure:
 - 1-3 sentences with the overall judgment
 - Then a findings table with exactly these columns:
 
-| Issue | Severity | Description |
-| -- | -- | -- |
-| ... | BLOCKING/WARNING/INFO | 1-2 sentences max |
+| Issue | Severity | Disposition | Description |
+| -- | -- | -- | -- |
+| ... | BLOCKING/WARNING/INFO | FIX_IN_PR/HUMAN_DECISION/FOLLOW_UP | 1-2 sentences max |
+
+Use only the allowed pairs: `BLOCKING|WARNING` with `FIX_IN_PR|HUMAN_DECISION`,
+or `INFO` with `FOLLOW_UP`.
 
 ## Progress
 - Brief bullets for anything already acknowledged, fixed, or intentionally left
@@ -109,24 +117,23 @@ Format as clean GitHub-flavored markdown with this structure:
 
 ## Recommended Next Step
 - Exactly one of:
-  - `FIX_PR`: unresolved findings require a concrete branch change and are safe
-    for an automated fix-pr pass.
-  - `HUMAN_DECISION`: remaining concerns are metadata-only, optional, product or
-    style judgment, ambiguous, or need maintainer choice before more automation.
-  - `NO_AUTOMATED_ACTION`: no unresolved actionable work remains.
-- Include one sentence explaining why.
+  - `FIX_PR`: unresolved `FIX_IN_PR` findings require one bounded automated fix.
+  - `HUMAN_DECISION`: a required judgment must precede dependent branch changes.
+  - `NO_AUTOMATED_ACTION`: no unresolved in-PR work remains; follow-ups may exist.
+- Include one sentence explaining why. Never select `FIX_PR` for `FOLLOW_UP`
+  findings alone, and select `HUMAN_DECISION` when that decision must precede a
+  fix.
 
 ## Final Verdict
 - `SHIP`, `MINOR_ISSUES`, or `NEEDS_REWORK`
 
 ## Action Items
-- GitHub checkbox list using `- [ ]`
-- Include only required, concrete branch-change work in checkboxes. Keep optional
-  INFO notes, metadata-only cleanup, and human-judgment nits out of automation
-  action items unless the PR request explicitly makes them required.
+- Include only unresolved `FIX_IN_PR` work, using the literal form
+  `- [ ] FIX_IN_PR: <bounded task>`.
+- Do not include `FOLLOW_UP` or `HUMAN_DECISION` items as checkboxes.
 
-If there are no actionable issues, include a single findings-table row that says
-so, omit "Issue Details", set Recommended Next Step to `NO_AUTOMATED_ACTION`,
-and keep the verdict consistent with that outcome.
+If no `FIX_IN_PR` or `HUMAN_DECISION` findings remain, set Recommended Next Step
+to `NO_AUTOMATED_ACTION`. `FOLLOW_UP` findings alone must not produce
+`NEEDS_REWORK`.
 
 Do not include a preamble.

--- a/.github/prompts/review.md
+++ b/.github/prompts/review.md
@@ -11,6 +11,11 @@ Gather current PR context before judging the change:
 The checked-out repository reflects the PR base branch for workflow safety, so
 treat the live PR diff as the source of truth for proposed changes.
 
+Before reviewing, establish the intended scope from the PR description, linked
+issue and acceptance criteria, and explicit maintainer direction. Do not make
+general hardening a requirement of a focused PR. When optional behavior raises
+a broader concern, prefer a small fail-closed mitigation over expanding the PR.
+
 This review phase must not mutate GitHub state:
 - do not submit a PR review with `gh`
 - do not post inline review comments
@@ -57,10 +62,16 @@ Review in this order:
 3. Tests: are the risky parts covered by real, meaningful tests that exercise behavior rather than only shallow happy paths?
 4. Documentation and workflow fit: are the docs, prompts, and workflow notes the most efficient way to communicate the change, and do workflow or automation changes make operational sense?
 
-Categorize each finding as:
-- **BLOCKING**
-- **WARNING**
-- **INFO**
+Categorize each finding by severity and disposition:
+- **BLOCKING** or **WARNING** with `FIX_IN_PR`: bounded work required in this PR
+- **BLOCKING** or **WARNING** with `HUMAN_DECISION`: a product or scope choice
+  needed before dependent changes
+- **INFO** with `FOLLOW_UP`: valid but optional, pre-existing, or scope-expanding
+  work that must not block this PR
+
+Include the disposition and a brief scope rationale with every finding. Do not
+use other severity/disposition combinations. `FOLLOW_UP` findings alone must not
+produce `NEEDS_REWORK`.
 
 End with:
 1. An overall verdict: SHIP / MINOR_ISSUES / NEEDS_REWORK


### PR DESCRIPTION
## Summary

- classify review findings independently as `FIX_IN_PR`, `FOLLOW_UP`, or `HUMAN_DECISION`
- allow synthesis to send only labeled `FIX_IN_PR` items to automated fixes
- stop orchestration after one completed automatic fix pass
- make orchestrated fix-pr runs execute only their selected bounded task

## Scope

Limited to the four prompts that own review, synthesis, routing, and fix execution. Each prompt states only its part of the contract; no runtime, workflow, test, documentation, or release-note changes are included.

The branch was rewritten to one concise commit after the initial orchestration canary exposed duplicated prompt policy.

## Verification

- `npm --prefix .agent run build`
- `npm --prefix .agent run check:docs`
- `git diff --check`
